### PR TITLE
Add checks against local database

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ We know computers use electricity, and because most of the electricity we use co
 
 The CO2 package from The Green Web Foundation lets you quickly estimate these emissions, to allow people who build digital services to optimise for carbon, the same way we use performance budgets to optimise our software.
 
-It does this by implementing the 1byte model as used by the Shift Project, as introduced in their report on CO3 emission from digital infrastructure, [Lean ICT: for a sober digital], to return a number for the estimated Co2 emissions for the corresponding number of bytes sent over the wire.
+It does this by implementing the 1byte model as used by the Shift Project, as introduced in their report on CO3 emission from digital infrastructure, [Lean ICT: for a sober digital][soberDigital], to return a number for the estimated Co2 emissions for the corresponding number of bytes sent over the wire.
 
 It is currently used in the web performance tool sitespeed.io, to help developers build greener, more planet friendly digital services.
 
@@ -21,6 +21,18 @@ const bytesSent = 1_000_000
 estimatedCO2 = co2.perByte(bytesSent)
 
 console.log(`Sending a million bytes, had a carbon footprint of ${estimatedCO2.toFixed(3)} grams of CO2`)
+
+```
+
+Because different digital services and websites use different forms of power, there is also a module for checking if a domain uses green power or not, and whether the domains linked to on a page use green power as well.
+
+```js
+
+const greencheck = require('@tgwf/hosting')
+
+greencheck.check("google.com") // returns true if green, otherwise false
+greencheck.checkMulti(["google.com", "kochindustries.com"]) // returns an array of the green domains, in this case ["google.com"]
+greencheck.checkPage(["google.com"]) // returns an array of green domains, again in this case, ["google.com"]
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# CO2
+
+We know computers use electricity, and because most of the electricity we use comes from burning fossil fuels to generate, there is an environmental cost to every upload and download we make over the internet.
+
+The CO2 package from The Green Web Foundation lets you quickly estimate these emissions, to allow people who build digital services to optimise for carbon, the same way we use performance budgets to optimise our software.
+
+It does this by implementing the 1byte model as used by the Shift Project, as introduced in their report on CO3 emission from digital infrastructure, [Lean ICT: for a sober digital], to return a number for the estimated Co2 emissions for the corresponding number of bytes sent over the wire.
+
+It is currently used in the web performance tool sitespeed.io, to help developers build greener, more planet friendly digital services.
+
+[soberDigital]: https://theshiftproject.org/en/lean-ict-2/
+
+
+## Usage
+
+```js
+
+const co2 = require('@tgwf/co2')
+const bytesSent = 1_000_000
+
+estimatedCO2 = co2.perByte(bytesSent)
+
+console.log(`Sending a million bytes, had a carbon footprint of ${estimatedCO2.toFixed(3)} grams of CO2`)
+
+```
+
+# Licenses
+
+Apache 2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tgwf/co2",
-  "version": "0.0.1",
+  "version": "0.0.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -547,6 +547,14 @@
       "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz",
       "integrity": "sha1-MrSzEF6IYQQ6b5rHVdgOVC02WzE="
     },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -2005,6 +2013,11 @@
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -274,6 +274,15 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "better-sqlite3": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-5.4.3.tgz",
+      "integrity": "sha512-fPp+8f363qQIhuhLyjI4bu657J/FfMtgiiHKfaTsj3RWDkHlWC1yT7c6kHZDnBxzQVoAINuzg553qKmZ4F1rEw==",
+      "requires": {
+        "integer": "^2.1.0",
+        "tar": "^4.4.10"
+      }
+    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
@@ -367,6 +376,11 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "ci-info": {
       "version": "2.0.0",
@@ -709,6 +723,14 @@
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "requires": {
+        "minipass": "^2.6.0"
       }
     },
     "fs.realpath": {
@@ -1181,6 +1203,11 @@
           }
         }
       }
+    },
+    "integer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/integer/-/integer-2.1.0.tgz",
+      "integrity": "sha512-vBtiSgrEiNocWvvZX1RVfeOKa2mCHLZQ2p9nkQkQZ/BvEiY+6CcUz0eyjvIiewjJoeNidzg2I+tpPJvpyspL1w=="
     },
     "intel": {
       "version": "1.2.0",
@@ -1947,6 +1974,38 @@
         "is-plain-obj": "^1.1.0"
       }
     },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "requires": {
+        "minipass": "^2.9.0"
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -2498,6 +2557,11 @@
         "tslib": "^1.9.0"
       }
     },
+    "safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2700,6 +2764,20 @@
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
       "dev": true
+    },
+    "tar": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      }
     },
     "term-size": {
       "version": "2.2.0",
@@ -2932,8 +3010,7 @@
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yaml": {
       "version": "1.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -528,6 +528,11 @@
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "dev": true
     },
+    "dbug": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz",
+      "integrity": "sha1-MrSzEF6IYQQ6b5rHVdgOVC02WzE="
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -817,7 +822,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
@@ -825,8 +829,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         }
       }
     },
@@ -1176,6 +1179,61 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        }
+      }
+    },
+    "intel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/intel/-/intel-1.2.0.tgz",
+      "integrity": "sha1-EdEUfraz9Fgr31M3s31UFYTp5B4=",
+      "requires": {
+        "chalk": "^1.1.0",
+        "dbug": "~0.4.2",
+        "stack-trace": "~0.0.9",
+        "strftime": "~0.10.0",
+        "symbol": "~0.3.1",
+        "utcstring": "~0.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -2543,6 +2601,16 @@
         "through": "2"
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "strftime": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.10.0.tgz",
+      "integrity": "sha1-s/D6QZKVICpaKJ9ta+n0kJphcZM="
+    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -2621,6 +2689,11 @@
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
       }
+    },
+    "symbol": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.3.1.tgz",
+      "integrity": "sha1-tvmpANSWpX8CQI8iGYwQndoGMEE="
     },
     "symbol-observable": {
       "version": "1.2.0",
@@ -2746,6 +2819,11 @@
         "ip-regex": "^4.1.0",
         "tlds": "^1.203.0"
       }
+    },
+    "utcstring": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
+      "integrity": "sha1-Qw/VEKt/yVtdWRDJAteYgMIIQ2s="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tgwf/co2",
-  "version": "0.0.2-0",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "yarn": false
   },
   "dependencies": {
+    "better-sqlite3": "^5.4.3",
     "intel": "^1.2.0"
-  }
+  },
+  "database_name": "../url2green.db"
 }

--- a/package.json
+++ b/package.json
@@ -20,5 +20,9 @@
   "devDependencies": {
     "np": "^6.1.0",
     "pagexray": "^2.5.9"
+  },
+  "np": {
+    "yarn": false,
+    "contents": "src"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^5.4.3",
-    "intel": "^1.2.0"
+    "debug": "^4.1.1"
   },
   "database_name": "../url2green.db"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tgwf/co2",
-  "version": "0.0.1",
+  "version": "0.0.2-0",
   "description": "Work out the co2 of your digital services",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "pagexray": "^2.5.9"
   },
   "np": {
-    "yarn": false,
-    "contents": "src"
+    "yarn": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   },
   "np": {
     "yarn": false
+  },
+  "dependencies": {
+    "intel": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tgwf/co2",
-  "version": "0.0.2-0",
+  "version": "0.0.2",
   "description": "Work out the co2 of your digital services",
   "main": "index.js",
   "scripts": {

--- a/src/hosting.js
+++ b/src/hosting.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const log = require('intel').getLogger('sitespeedio.plugin.sustainable');
+const https = require('https');
+
+async function getBody(url) {
+  // Return new promise
+  return new Promise(function (resolve, reject) {
+    // Do async job
+    const req = https.get(url, function (res) {
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        log.error(
+          'Could not get info from the Green Web Foundation API, %s for %s',
+          res.statusCode,
+          url
+        );
+        return reject(new Error(`Status Code: ${res.statusCode}`));
+      }
+      const data = [];
+
+      res.on('data', chunk => {
+        data.push(chunk);
+      });
+
+      res.on('end', () => resolve(Buffer.concat(data).toString()));
+    });
+    req.end();
+  });
+}
+async function greenDomains(pageXray) {
+  const domains = Object.keys(pageXray.domains);
+
+  try {
+    const allGreenCheckResults = JSON.parse(
+      await getBody(
+        `https://api.thegreenwebfoundation.org/v2/greencheckmulti/${JSON.stringify(
+          domains
+        )}`
+      )
+    );
+
+    const entries = Object.entries(allGreenCheckResults);
+    // TODO find the preferred way for assigning vars
+    // when making key value pairs , but only using the val
+
+    /* eslint-disable-next-line */
+    let greenEntries = entries.filter(function ([key, val]) {
+      return val.green;
+    });
+    /* eslint-disable-next-line */
+    return greenEntries.map(function ([key, val]) {
+      return val.url;
+    });
+  } catch (e) {
+    return [];
+  }
+}
+
+module.exports = {
+  greenDomains
+};

--- a/src/hosting.js
+++ b/src/hosting.js
@@ -3,33 +3,50 @@
 const log = require('intel').getLogger('sitespeedio.plugin.sustainable');
 const https = require('https');
 
-async function getBody(url) {
-  // Return new promise
-  return new Promise(function (resolve, reject) {
-    // Do async job
-    const req = https.get(url, function (res) {
-      if (res.statusCode < 200 || res.statusCode >= 300) {
-        log.error(
-          'Could not get info from the Green Web Foundation API, %s for %s',
-          res.statusCode,
-          url
-        );
-        return reject(new Error(`Status Code: ${res.statusCode}`));
-      }
-      const data = [];
+const Database = require('better-sqlite3');
+// keep the name in package.json so its easy just to chanfe
+const DATABASE_NAME = require('../package').database_name;
 
-      res.on('data', chunk => {
-        data.push(chunk);
-      });
+console.log(DATABASE_NAME)
 
-      res.on('end', () => resolve(Buffer.concat(data).toString()));
-    });
-    req.end();
-  });
+function getQ(domains) {
+  const q = [];
+  for (let domain of domains) {
+    q.push('?')
+  }
+  return q.join(',');
 }
-async function greenDomains(pageXray) {
-  const domains = Object.keys(pageXray.domains);
 
+function getDatabase() {
+  // try {
+  return new Database(`./data/${DATABASE_NAME}`, { readonly: true, fileMustExist: true })
+  // } catch (SqliteError) {
+  // return false
+  // }
+}
+
+function check(domain) {
+  const db = getDatabase();
+
+
+
+
+  if (db) {
+    try {
+      const stmt = db.prepare('SELECT * FROM green_presenting WHERE url = ?');
+      return [stmt.get(domain).url];
+
+
+    } finally {
+      if (db) {
+        db.close();
+      }
+    }
+  }
+  // fall back to using the API
+  return checkDomains([domain])
+}
+async function checkDomains(domains) {
   try {
     const allGreenCheckResults = JSON.parse(
       await getBody(
@@ -56,6 +73,50 @@ async function greenDomains(pageXray) {
   }
 }
 
+function getDomains(domains) {
+  const db = getDatabase();
+  try {
+    const stmt = db.prepare(`SELECT * FROM green_presenting WHERE url in (${getQ(domains)})`);
+    return stmt.all(domains);
+  } finally {
+    if (db) {
+      db.close();
+    }
+  }
+}
+
+async function getBody(url) {
+  // Return new promise
+  return new Promise(function (resolve, reject) {
+    // Do async job
+    const req = https.get(url, function (res) {
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        log.error(
+          'Could not get info from the Green Web Foundation API, %s for %s',
+          res.statusCode,
+          url
+        );
+        return reject(new Error(`Status Code: ${res.statusCode}`));
+      }
+      const data = [];
+
+      res.on('data', chunk => {
+        data.push(chunk);
+      });
+
+      res.on('end', () => resolve(Buffer.concat(data).toString()));
+    });
+    req.end();
+  });
+}
+async function greenDomainsForPage(pageXray) {
+  const domains = Object.keys(pageXray.domains);
+
+  return checkDomains(domains)
+
+}
+
 module.exports = {
-  greenDomains
+  greenDomainsForPage,
+  check
 };

--- a/src/hosting.js
+++ b/src/hosting.js
@@ -1,13 +1,9 @@
 'use strict';
 
-const log = require('intel').getLogger('sitespeedio.plugin.sustainable');
+const log = require('debug')('tgwf:hosting');
 const https = require('https');
 
 const Database = require('better-sqlite3');
-// keep the name in package.json so its easy just to chanfe
-const DATABASE_NAME = require('../package').database_name;
-
-console.log(DATABASE_NAME)
 
 function getQ(domains) {
   const q = [];
@@ -17,36 +13,79 @@ function getQ(domains) {
   return q.join(',');
 }
 
-function getDatabase() {
-  // try {
-  return new Database(`./data/${DATABASE_NAME}`, { readonly: true, fileMustExist: true })
-  // } catch (SqliteError) {
-  // return false
-  // }
+function getDatabase(databaseName) {
+
+  if (databaseName) {
+    log(`looking for db at ${databaseName}`)
+    return new Database(`./data/${databaseName}`, { readonly: true, fileMustExist: true })
+  }
+  else {
+    // keep the name in package.json so its easy just to change
+    const DATABASE_NAME = require('../package').database_name;
+    log(`looking for db at ${DATABASE_NAME}`)
+    return new Database(`./data/${DATABASE_NAME}`, { readonly: true, fileMustExist: true })
+  }
 }
 
-function check(domain) {
-  const db = getDatabase();
+function check(domain, dbName) {
+  let db;
 
+  try {
+    db = getDatabase(dbName)
+  }
+  catch (SqliteError) {
+    log(`couldn't find SQlite database at path: ${dbName}`)
+  }
 
+  // is it a single domain or an array of them?
+  if (typeof domain === 'string') {
+    return checkSingleDomain(domain, db)
+  }
+  else {
+    return checkDomains(domain, db)
+  }
+}
 
+function checkSingleDomain(domain, db) {
+  try {
+    return checkInDB(domain, db)
+  }
+  catch {
+    return checkAgainstAPI(domain)
+  }
+}
 
-  if (db) {
-    try {
-      const stmt = db.prepare('SELECT * FROM green_presenting WHERE url = ?');
-      return [stmt.get(domain).url];
+function checkDomains(domains, db) {
+  try {
+    return checkDomainsInDB(domains, db)
+  }
+  catch {
+    return checkDomainsAgainstAPI(domains)
+  }
+}
 
+function checkInDB(domain, db) {
 
-    } finally {
-      if (db) {
-        db.close();
-      }
+  try {
+    const stmt = db.prepare('SELECT * FROM green_presenting WHERE url = ?');
+    return !!stmt.get(domain).green;
+  } finally {
+    if (db) {
+      db.close();
     }
   }
-  // fall back to using the API
-  return checkDomains([domain])
 }
-async function checkDomains(domains) {
+
+async function checkAgainstAPI(domain) {
+  const res = JSON.parse(
+    await getBody(
+      `https://api.thegreenwebfoundation.org/greencheck/${domain}`
+    )
+  );
+  return res.green
+}
+
+async function checkDomainsAgainstAPI(domains) {
   try {
     const allGreenCheckResults = JSON.parse(
       await getBody(
@@ -56,28 +95,33 @@ async function checkDomains(domains) {
       )
     );
 
-    const entries = Object.entries(allGreenCheckResults);
-    // TODO find the preferred way for assigning vars
-    // when making key value pairs , but only using the val
+    return greenDomainsFromResults(allGreenCheckResults)
 
-    /* eslint-disable-next-line */
-    let greenEntries = entries.filter(function ([key, val]) {
-      return val.green;
-    });
-    /* eslint-disable-next-line */
-    return greenEntries.map(function ([key, val]) {
-      return val.url;
-    });
   } catch (e) {
     return [];
   }
 }
 
-function getDomains(domains) {
-  const db = getDatabase();
+function greenDomainsFromResults(greenResults) {
+  const entries = Object.entries(greenResults);
+  let greenEntries = entries.filter(function ([key, val]) {
+    return val.green;
+  });
+
+  return greenEntries.map(function ([key, val]) {
+    return val.url;
+  });
+}
+
+function checkDomainsInDB(domains, db) {
+
   try {
     const stmt = db.prepare(`SELECT * FROM green_presenting WHERE url in (${getQ(domains)})`);
-    return stmt.all(domains);
+
+    res = stmt.all(domains);
+
+    return greenDomainsFromResults(res)
+
   } finally {
     if (db) {
       db.close();
@@ -109,7 +153,7 @@ async function getBody(url) {
     req.end();
   });
 }
-async function greenDomainsForPage(pageXray) {
+async function checkPage(pageXray) {
   const domains = Object.keys(pageXray.domains);
 
   return checkDomains(domains)
@@ -117,6 +161,7 @@ async function greenDomainsForPage(pageXray) {
 }
 
 module.exports = {
-  greenDomainsForPage,
-  check
+  check,
+  checkMulti: checkDomains,
+  checkPage,
 };

--- a/src/hosting.test.js
+++ b/src/hosting.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const co2 = require('./co2');
+const hosting = require('./hosting');
+const pagexray = require('pagexray');
+
+
+
+describe('hosting', function () {
+  let har;
+  beforeEach(function () {
+    har = JSON.parse(fs
+      .readFileSync(path.resolve(__dirname, '../data/fixtures/tgwf.har'), 'utf8'))
+  });
+  describe('greenDomains', async function () {
+    it('it returns a list of green domains, when passed a page object', async function () {
+      const pages = pagexray.convert(har);
+      const pageXrayRun = pages[0];
+
+      // TODO find a way to not hit the API each time
+      const greenDomains = await hosting.greenDomains(pageXrayRun);
+
+      expect(greenDomains)
+        .toHaveLength(10);
+
+      const expectedGreendomains = [
+        'thegreenwebfoundation.org',
+        'www.thegreenwebfoundation.org',
+        'fonts.googleapis.com',
+        'ajax.googleapis.com',
+        'assets.digitalclimatestrike.net',
+        'cdnjs.cloudflare.com',
+        'graphite.thegreenwebfoundation.org',
+        'analytics.thegreenwebfoundation.org',
+        'fonts.gstatic.com',
+        'api.thegreenwebfoundation.org'
+      ];
+      greenDomains.forEach(function (dom) {
+        expect(expectedGreendomains).toContain(dom);
+      });
+    });
+    it(
+      'it returns an empty list, when passed a page object with no green domains'
+    );
+  });
+});

--- a/src/hosting.test.js
+++ b/src/hosting.test.js
@@ -15,13 +15,13 @@ describe('hosting', function () {
     har = JSON.parse(fs
       .readFileSync(path.resolve(__dirname, '../data/fixtures/tgwf.har'), 'utf8'))
   });
-  describe('greenDomains', async function () {
+  describe('greenDomainsForPage', async function () {
     it('it returns a list of green domains, when passed a page object', async function () {
       const pages = pagexray.convert(har);
       const pageXrayRun = pages[0];
 
       // TODO find a way to not hit the API each time
-      const greenDomains = await hosting.greenDomains(pageXrayRun);
+      const greenDomains = await hosting.greenDomainsForPage(pageXrayRun);
 
       expect(greenDomains)
         .toHaveLength(10);
@@ -46,4 +46,15 @@ describe('hosting', function () {
       'it returns an empty list, when passed a page object with no green domains'
     );
   });
+  describe('checking a single domain against the local db', async function () {
+    it("tries to use a local database if available ", function () {
+      const res = hosting.check("google.com")
+      expect(res).toEqual(["google.com"])
+    })
+    it("falls back to using the API to check instead")
+  })
+  describe('checking a multiple domains against the local db', async function () {
+    it("tries to use a local database if available")
+    it("falls back to the API when no db is present")
+  })
 });

--- a/src/hosting.test.js
+++ b/src/hosting.test.js
@@ -21,7 +21,7 @@ describe('hosting', function () {
       const pageXrayRun = pages[0];
 
       // TODO find a way to not hit the API each time
-      const greenDomains = await hosting.greenDomainsForPage(pageXrayRun);
+      const greenDomains = await hosting.checkPage(pageXrayRun);
 
       expect(greenDomains)
         .toHaveLength(10);
@@ -47,14 +47,25 @@ describe('hosting', function () {
     );
   });
   describe('checking a single domain against the local db', async function () {
-    it("tries to use a local database if available ", function () {
-      const res = hosting.check("google.com")
-      expect(res).toEqual(["google.com"])
+    it("tries to use a local database if available ", async function () {
+      const res = await hosting.check("google.com")
+      expect(res).toEqual(true)
     })
-    it("falls back to using the API to check instead")
+    it("falls back to using the API to check instead", async function () {
+      const res = await hosting.check("google.com", "incorrectDatabasePath")
+      expect(res).toEqual(true)
+    })
+
   })
   describe('checking a multiple domains against the local db', async function () {
-    it("tries to use a local database if available")
-    it("falls back to the API when no db is present")
+    it("tries to use a local database if available", async function () {
+      const res = await hosting.check(["google.com", "kochindustries.com"])
+      expect(res).toContain("google.com")
+    })
+    it("falls back to the API when no db is present", async function () {
+      const res = await hosting.check(["google.com", "kochindustries.com"], "incorrectDatabasePath")
+      expect(res).toContain("google.com")
+    })
+
   })
 });


### PR DESCRIPTION
This adds tests for using a local SQlite database for performing greenchecks as downloadable from http://thegreenwebfoundation.org/green-web-datasets/, instead of using the API.

