### PR TITLE
Intro Green Byte model, use mean energy per Gb for 1byte, and fix one number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tgwf/co2",
-  "version": "0.4.0",
+  "version": "0.4.3",
   "description": "Work out the co2 of your digital services",
   "main": "src/index.js",
   "scripts": {

--- a/src/1byte.js
+++ b/src/1byte.js
@@ -1,0 +1,24 @@
+
+// Use the 1byte model for now from the Shift Project, and assume a US grid mix figure they use of around 519 g co2 for the time being. It's lower for Europe, and in particular, France, but for v1, we don't include this
+const CO2_PER_KWH_IN_DC_GREY = 519;
+
+// the 1 byte model gives figures for energy usage for:
+
+// datacentres
+// networks
+// the device used to access a site/app
+
+// The device usage figure combines figures for:
+//  1. the usage for devices (which is small proportion of the energy use)
+//  2. the *making* the device, which is comparitively high.
+
+const KWH_PER_BYTE_IN_DC = 0.00000000072;
+const KWH_PER_BYTE_FOR_NETWORK = 0.00000000488;
+
+const KWH_PER_BYTE_FOR_DEVICES = 0.00000000013
+module.export = {
+  KWH_PER_BYTE_IN_DC,
+  KWH_PER_BYTE_FOR_NETWORK,
+  KWH_PER_BYTE_FOR_DEVICES,
+  CO2_PER_KWH_NETWORK_GREY
+}

--- a/src/1byte.js
+++ b/src/1byte.js
@@ -13,12 +13,16 @@ const CO2_PER_KWH_IN_DC_GREY = 519;
 //  2. the *making* the device, which is comparitively high.
 
 const KWH_PER_BYTE_IN_DC = 0.00000000072;
+
+// this is probably best left as something users can define, or
+// a weighted average based on total usage.
+// Pull requests gratefully accepted
 const KWH_PER_BYTE_FOR_NETWORK = 0.00000000488;
 
 const KWH_PER_BYTE_FOR_DEVICES = 0.00000000013
-module.export = {
+module.exports = {
   KWH_PER_BYTE_IN_DC,
   KWH_PER_BYTE_FOR_NETWORK,
   KWH_PER_BYTE_FOR_DEVICES,
-  CO2_PER_KWH_NETWORK_GREY
+  CO2_PER_KWH_IN_DC_GREY
 }

--- a/src/co2.js
+++ b/src/co2.js
@@ -1,10 +1,14 @@
 'use strict';
 
 const url = require('url');
+const oneByte = require('./1byte.js');
 
-// Use the 1byte model for now from the Shift Project, and assume a US grid mix of around 519 g co2 for the time being.
-const CO2_PER_KWH_IN_DC_GREY = 519;
-const CO2_PER_KWH_IN_DC_GREEN = 33;
+const KWH_PER_BYTE_IN_DC = oneByte.KWH_PER_BYTE_IN_DC;
+const KWH_PER_BYTE_FOR_NETWORK = oneByte.KWH_PER_BYTE_FOR_NETWORK
+const CO2_PER_KWH_IN_DC_GREY = oneByte.CO2_PER_KWH_IN_DC_GREY
+
+// this figure is from the IEA's 2018 report for a global average:
+const CO2_PER_KWH_NETWORK_GREY = 495;
 
 // the better way would be do to this with a weighted average of types of RE generation
 // from solar, to wind, to biomass, and hydro and so on, based on how much they
@@ -17,15 +21,8 @@ const CO2_PER_KWH_IN_DC_GREEN = 33;
 // https://twitter.com/mrchrisadams/status/1227972969756086284
 // https://en.wikipedia.org/wiki/Life-cycle_greenhouse-gas_emissions_of_energy_sources
 
-// 33.4, but that's for the UK in 2014/15. Shouldn't be too off though. Probably lower now.
+const CO2_PER_KWH_IN_DC_GREEN = 33;
 
-const CO2_PER_KWH_NETWORK_GREY = 495;
-
-// these are the figures pulled from the 1byte model, there is a
-// third figure to represent carbon emission from *making* the device used to access a site/app but we lieave it out as it relies on
-// us knowing how long it's being used to read content
-const KWH_PER_BYTE_IN_DC = 0.00000000072;
-const KWH_PER_BYTE_FOR_NETWORK = 0.00000000152;
 
 function getCO2PerByte(bytes, green) {
   // return a CO2 figure for energy used to shift the corresponding

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -10,13 +10,13 @@ const pagexray = require('pagexray');
 describe('sustainableWeb', function () {
   describe('co2', function () {
     let har;
-    const TGWF_GREY_VALUE = 0.8193815884799998;
+    const TGWF_GREY_VALUE = 2.0484539712;
     const TGWF_GREEN_VALUE = 0.54704300112;
-    const TGWF_MIXED_VALUE = 0.57128033088;
+    const TGWF_MIXED_VALUE = 1.7485750598399998;
 
     const MILLION = 1000000;
-    const MILLION_GREY = 1.1625599999999998;
-    const MILLION_GREEN = 0.77616;
+    const MILLION_GREY = 2.9064;
+    const MILLION_GREEN = 2.4393599999999998;
 
     beforeEach(function () {
       har = JSON.parse(fs
@@ -31,7 +31,7 @@ describe('sustainableWeb', function () {
       });
 
       it("returns a lower CO2 number for data transfer from domains using entirely 'green' power", function () {
-        expect(co2.perByte(MILLION, false)).toBe(1.1625599999999998);
+        expect(co2.perByte(MILLION, false)).toBe(MILLION_GREY);
         expect(co2.perByte(MILLION, true)).toBe(MILLION_GREEN);
       });
     });

--- a/src/green-byte.js
+++ b/src/green-byte.js
@@ -1,0 +1,28 @@
+
+// PLEASE DO NOT USE THIS MODEL YET FOR CALCS
+
+const CO2_PER_KWH_IN_DC_GREY = 519;
+
+// this subs in the IEA's recent figure in analyis from the carbon brief
+// https://www.carbonbrief.org/factcheck-what-is-the-carbon-footprint-of-streaming-video-on-netflix
+
+// datacentres
+const KWH_PER_BYTE_IN_DC = 0.00000000007;
+
+// networks
+const KWH_PER_BYTE_FOR_NETWORK = 0.00000000058;
+
+// the device used to access a site/app
+const KWH_PER_BYTE_FOR_DEVICES = 0.00000000055;
+
+// The device usage figure combines figures for:
+//  1. the usage for devices (which is small proportion of the energy use)
+//  2. the *making* the device, which is comparitively high.
+
+
+module.exports = {
+  KWH_PER_BYTE_IN_DC,
+  KWH_PER_BYTE_FOR_NETWORK,
+  KWH_PER_BYTE_FOR_DEVICES,
+  CO2_PER_KWH_IN_DC_GREY
+}

--- a/src/hosting.test.js
+++ b/src/hosting.test.js
@@ -45,7 +45,7 @@ describe('hosting', function () {
   });
   describe('checking a single domain with #check', function () {
     it("tries to use a local database", async function () {
-      const res = await hosting.check("google.com",path.resolve(__dirname, "..", "url2green.test.db"))
+      const res = await hosting.check("google.com", path.resolve(__dirname, "..", "url2green.test.db"))
       expect(res).toEqual(true)
     })
     it("use the API instead", async function () {
@@ -66,7 +66,7 @@ describe('hosting', function () {
   })
   describe('explicitly checking multiple domains with #checkMulti', function () {
     it("tries to use a local database if available", async function () {
-      const res = await hosting.check(["google.com", "kochindustries.com"],  path.resolve(__dirname, "..", "url2green.test.db"))
+      const res = await hosting.check(["google.com", "kochindustries.com"], path.resolve(__dirname, "..", "url2green.test.db"))
       expect(res).toContain("google.com")
     })
     it("use the API", async function () {


### PR DESCRIPTION
This PR adds to things:

- it introduces the idea of the green byte model, as alluded to in #2 
- it updates the tests to an average fig for emissions, not just wifi