### PR TITLE
Split database/API and remove database location in the package.json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Because different digital services and websites use different forms of power, th
 const greencheck = require('@tgwf/hosting')
 
 greencheck.check("google.com") // returns true if green, otherwise false
-greencheck.checkMulti(["google.com", "kochindustries.com"]) // returns an array of the green domains, in this case ["google.com"]
+greencheck.check(["google.com", "kochindustries.com"]) // returns an array of the green domains, in this case ["google.com"]
 greencheck.checkPage(["google.com"]) // returns an array of green domains, again in this case, ["google.com"]
 
 ```

--- a/package.json
+++ b/package.json
@@ -28,6 +28,5 @@
   "dependencies": {
     "better-sqlite3": "^5.4.3",
     "debug": "^4.1.1"
-  },
-  "database_name": "../url2green.db"
+  }
 }

--- a/src/hosting.js
+++ b/src/hosting.js
@@ -1,111 +1,21 @@
 'use strict';
 
 const log = require('debug')('tgwf:hosting');
-const https = require('https');
-
-const Database = require('better-sqlite3');
-
-function getQ(domains) {
-  const q = [];
-  for (let domain of domains) {
-    q.push('?')
-  }
-  return q.join(',');
-}
-
-function getDatabase(databaseName) {
-
-  if (databaseName) {
-    log(`looking for db at ${databaseName}`)
-    return new Database(`./data/${databaseName}`, { readonly: true, fileMustExist: true })
-  }
-  else {
-    // keep the name in package.json so its easy just to change
-    const DATABASE_NAME = require('../package').database_name;
-    log(`looking for db at ${DATABASE_NAME}`)
-    return new Database(`./data/${DATABASE_NAME}`, { readonly: true, fileMustExist: true })
-  }
-}
+const hostingAPI = require('./hostingAPI');
+const hostingDatabase = require('./hostingDatabase');
 
 function check(domain, dbName) {
-  let db;
-
-  try {
-    db = getDatabase(dbName)
-  }
-  catch (SqliteError) {
-    log(`couldn't find SQlite database at path: ${dbName}`)
-  }
-
-  // is it a single domain or an array of them?
-  if (typeof domain === 'string') {
-    return checkSingleDomain(domain, db)
-  }
-  else {
-    return checkDomains(domain, db)
-  }
-}
-
-function checkSingleDomain(domain, db) {
-  try {
-    return checkInDB(domain, db)
-  }
-  catch {
-    return checkAgainstAPI(domain)
-  }
-}
-
-function checkDomains(domains, db) {
-  try {
-    return checkDomainsInDB(domains, db)
-  }
-  catch {
-    return checkDomainsAgainstAPI(domains)
-  }
-}
-
-function checkInDB(domain, db) {
-
-  try {
-    const stmt = db.prepare('SELECT * FROM green_presenting WHERE url = ?');
-    return !!stmt.get(domain).green;
-  } finally {
-    if (db) {
-      db.close();
-    }
-  }
-}
-
-async function checkAgainstAPI(domain) {
-  const res = JSON.parse(
-    await getBody(
-      `https://api.thegreenwebfoundation.org/greencheck/${domain}`
-    )
-  );
-  return res.green
-}
-
-async function checkDomainsAgainstAPI(domains) {
-  try {
-    const allGreenCheckResults = JSON.parse(
-      await getBody(
-        `https://api.thegreenwebfoundation.org/v2/greencheckmulti/${JSON.stringify(
-          domains
-        )}`
-      )
-    );
-
-    return greenDomainsFromResults(allGreenCheckResults)
-
-  } catch (e) {
-    return [];
+  if (dbName) {
+    return hostingDatabase.check(domain, dbName)
+  } else {
+    return hostingAPI.check(domain);
   }
 }
 
 function greenDomainsFromResults(greenResults) {
-  const entries = Object.entries(greenResults);
+  const entries = Object.entries(greenResults)
   let greenEntries = entries.filter(function ([key, val]) {
-    return val.green;
+    return val.green
   });
 
   return greenEntries.map(function ([key, val]) {
@@ -113,55 +23,13 @@ function greenDomainsFromResults(greenResults) {
   });
 }
 
-function checkDomainsInDB(domains, db) {
-
-  try {
-    const stmt = db.prepare(`SELECT * FROM green_presenting WHERE url in (${getQ(domains)})`);
-
-    res = stmt.all(domains);
-
-    return greenDomainsFromResults(res)
-
-  } finally {
-    if (db) {
-      db.close();
-    }
-  }
-}
-
-async function getBody(url) {
-  // Return new promise
-  return new Promise(function (resolve, reject) {
-    // Do async job
-    const req = https.get(url, function (res) {
-      if (res.statusCode < 200 || res.statusCode >= 300) {
-        log(
-          'Could not get info from the Green Web Foundation API, %s for %s',
-          res.statusCode,
-          url
-        );
-        return reject(new Error(`Status Code: ${res.statusCode}`));
-      }
-      const data = [];
-
-      res.on('data', chunk => {
-        data.push(chunk);
-      });
-
-      res.on('end', () => resolve(Buffer.concat(data).toString()));
-    });
-    req.end();
-  });
-}
 async function checkPage(pageXray) {
-  const domains = Object.keys(pageXray.domains);
+  const domains = Object.keys(pageXray.domains)
   return checkDomains(domains)
-
 }
 
 module.exports = {
   check,
-  checkMulti: checkDomains,
   checkPage,
   greenDomains: checkDomains,
 };

--- a/src/hosting.js
+++ b/src/hosting.js
@@ -25,7 +25,7 @@ function greenDomainsFromResults(greenResults) {
 
 async function checkPage(pageXray) {
   const domains = Object.keys(pageXray.domains)
-  return checkDomains(domains)
+  return check(domains)
 }
 
 module.exports = {

--- a/src/hosting.js
+++ b/src/hosting.js
@@ -31,5 +31,5 @@ async function checkPage(pageXray) {
 module.exports = {
   check,
   checkPage,
-  greenDomains: checkDomains,
+  greenDomains: greenDomainsFromResults,
 };

--- a/src/hosting.test.js
+++ b/src/hosting.test.js
@@ -3,11 +3,8 @@
 const fs = require('fs');
 const path = require('path');
 
-const co2 = require('./co2');
 const hosting = require('./hosting');
 const pagexray = require('pagexray');
-
-
 
 describe('hosting', function () {
   let har;

--- a/src/hosting.test.js
+++ b/src/hosting.test.js
@@ -12,7 +12,7 @@ describe('hosting', function () {
     har = JSON.parse(fs
       .readFileSync(path.resolve(__dirname, '../data/fixtures/tgwf.har'), 'utf8'))
   });
-  describe('checking all domains on a page object with #checkPage ', async function () {
+  describe('checking all domains on a page object with #checkPage ', function () {
     it('it returns a list of green domains, when passed a page object', async function () {
       const pages = pagexray.convert(har);
       const pageXrayRun = pages[0];
@@ -43,7 +43,7 @@ describe('hosting', function () {
     //   'it returns an empty list, when passed a page object with no green domains'
     // );
   });
-  describe('checking a single domain with #check', async function () {
+  describe('checking a single domain with #check', function () {
     it("tries to use a local database if available ", async function () {
       const res = await hosting.check("google.com",path.resolve(__dirname, "..", "url2green.test.db"))
       expect(res).toEqual(true)
@@ -54,7 +54,7 @@ describe('hosting', function () {
     })
 
   })
-  describe('implicitly checking multiple domains with #check', async function () {
+  describe('implicitly checking multiple domains with #check', function () {
     it("tries to use a local database if available", async function () {
       const res = await hosting.check(["google.com", "kochindustries.com"], path.resolve(__dirname, "..", "url2green.test.db"))
       expect(res).toContain("google.com")
@@ -64,13 +64,13 @@ describe('hosting', function () {
       expect(res).toContain("google.com")
     })
   })
-  describe('explicitly checking multiple domains with #checkMulti', async function () {
+  describe('explicitly checking multiple domains with #checkMulti', function () {
     it("tries to use a local database if available", async function () {
-      const res = await hosting.checkMulti(["google.com", "kochindustries.com"])
+      const res = await hosting.check(["google.com", "kochindustries.com"],  path.resolve(__dirname, "..", "url2green.test.db"))
       expect(res).toContain("google.com")
     })
     it("use the API", async function () {
-      const res = await hosting.checkMulti(["google.com", "kochindustries.com"])
+      const res = await hosting.check(["google.com", "kochindustries.com"])
       expect(res).toContain("google.com")
     })
   })

--- a/src/hosting.test.js
+++ b/src/hosting.test.js
@@ -45,22 +45,22 @@ describe('hosting', function () {
   });
   describe('checking a single domain with #check', async function () {
     it("tries to use a local database if available ", async function () {
-      const res = await hosting.check("google.com", "../url2green.test.db")
+      const res = await hosting.check("google.com",path.resolve(__dirname, "..", "url2green.test.db"))
       expect(res).toEqual(true)
     })
-    it("falls back to using the API to check instead", async function () {
-      const res = await hosting.check("google.com", "incorrectDatabasePath")
+    it("Use the API instead", async function () {
+      const res = await hosting.check("google.com")
       expect(res).toEqual(true)
     })
 
   })
   describe('implicitly checking multiple domains with #check', async function () {
     it("tries to use a local database if available", async function () {
-      const res = await hosting.check(["google.com", "kochindustries.com"], "../url2green.test.db")
+      const res = await hosting.check(["google.com", "kochindustries.com"], path.resolve(__dirname, "..", "url2green.test.db"))
       expect(res).toContain("google.com")
     })
-    it("falls back to the API when no db is present", async function () {
-      const res = await hosting.check(["google.com", "kochindustries.com"], "incorrectDatabasePath")
+    it("Use the API", async function () {
+      const res = await hosting.check(["google.com", "kochindustries.com"])
       expect(res).toContain("google.com")
     })
   })
@@ -69,8 +69,8 @@ describe('hosting', function () {
       const res = await hosting.checkMulti(["google.com", "kochindustries.com"])
       expect(res).toContain("google.com")
     })
-    it("falls back to the API when no db is present", async function () {
-      const res = await hosting.checkMulti(["google.com", "kochindustries.com"], "incorrectDatabasePath")
+    it("use the API", async function () {
+      const res = await hosting.checkMulti(["google.com", "kochindustries.com"])
       expect(res).toContain("google.com")
     })
   })

--- a/src/hosting.test.js
+++ b/src/hosting.test.js
@@ -44,11 +44,11 @@ describe('hosting', function () {
     // );
   });
   describe('checking a single domain with #check', function () {
-    it("tries to use a local database if available ", async function () {
+    it("tries to use a local database", async function () {
       const res = await hosting.check("google.com",path.resolve(__dirname, "..", "url2green.test.db"))
       expect(res).toEqual(true)
     })
-    it("Use the API instead", async function () {
+    it("use the API instead", async function () {
       const res = await hosting.check("google.com")
       expect(res).toEqual(true)
     })

--- a/src/hostingAPI.js
+++ b/src/hostingAPI.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const log = require('debug')('tgwf:hostingAPI');
+const https = require('https');
+
+function check(domain) {
+  // is it a single domain or an array of them?
+  if (typeof domain === 'string') {
+    return checkAgainstAPI(domain)
+  }
+  else {
+    return checkDomainsAgainstAPI(domain)
+  }
+}
+
+async function checkAgainstAPI(domain) {
+  const res = JSON.parse(
+    await getBody(
+      `https://api.thegreenwebfoundation.org/greencheck/${domain}`
+    )
+  );
+  return res.green
+}
+
+async function checkDomainsAgainstAPI(domains) {
+  try {
+    const allGreenCheckResults = JSON.parse(
+      await getBody(
+        `https://api.thegreenwebfoundation.org/v2/greencheckmulti/${JSON.stringify(
+          domains
+        )}`
+      )
+    );
+
+    return greenDomainsFromResults(allGreenCheckResults)
+
+  } catch (e) {
+    return [];
+  }
+}
+
+function greenDomainsFromResults(greenResults) {
+  const entries = Object.entries(greenResults);
+  let greenEntries = entries.filter(function ([key, val]) {
+    return val.green;
+  });
+
+  return greenEntries.map(function ([key, val]) {
+    return val.url;
+  });
+}
+
+
+async function getBody(url) {
+  // Return new promise
+  return new Promise(function (resolve, reject) {
+    // Do async job
+    const req = https.get(url, function (res) {
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        log(
+          'Could not get info from the Green Web Foundation API, %s for %s',
+          res.statusCode,
+          url
+        );
+        return reject(new Error(`Status Code: ${res.statusCode}`));
+      }
+      const data = [];
+
+      res.on('data', chunk => {
+        data.push(chunk);
+      });
+
+      res.on('end', () => resolve(Buffer.concat(data).toString()));
+    });
+    req.end();
+  });
+}
+
+module.exports = {
+  check
+};

--- a/src/hostingAPI.test.js
+++ b/src/hostingAPI.test.js
@@ -4,14 +4,14 @@ const hosting = require('./hostingAPI');
 
 describe('hostingAPI', function () {
   describe('checking a single domain with #check', function () {
-    it("falls back to using the API to check instead", async function () {
+    it("using the API", async function () {
       const res = await hosting.check("google.com")
       expect(res).toEqual(true)
     })
 
   })
   describe('implicitly checking multiple domains with #check', function () {
-    it("falls back to the API when no db is present", async function () {
+    it("using the API", async function () {
       const res = await hosting.check(["google.com", "kochindustries.com"])
       expect(res).toContain("google.com")
     })

--- a/src/hostingAPI.test.js
+++ b/src/hostingAPI.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const hosting = require('./hostingAPI');
+
+describe('hostingAPI', function () {
+  describe('checking a single domain with #check', function () {
+    it("falls back to using the API to check instead", async function () {
+      const res = await hosting.check("google.com")
+      expect(res).toEqual(true)
+    })
+
+  })
+  describe('implicitly checking multiple domains with #check', function () {
+    it("falls back to the API when no db is present", async function () {
+      const res = await hosting.check(["google.com", "kochindustries.com"])
+      expect(res).toContain("google.com")
+    })
+  })
+});

--- a/src/hostingDatabase.js
+++ b/src/hostingDatabase.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const log = require('debug')('tgwf:hostingDatabase');
+const Database = require('better-sqlite3');
+
+function getQ(domains) {
+  const q = [];
+  for (let domain of domains) {
+    q.push('?')
+  }
+  return q.join(',');
+}
+
+function getDatabase(databaseFullPathAndName) {
+  log(`looking for db at ${databaseFullPathAndName}`)
+  return new Database(databaseFullPathAndName, { readonly: true, fileMustExist: true });
+}
+
+function check(domain, dbName) {
+  let db;
+
+  try {
+    db = getDatabase(dbName)
+  }
+  catch (SqliteError) {
+    log(`couldn't find SQlite database at path: ${dbName}`)
+    throw SqliteError
+  }
+
+  // is it a single domain or an array of them?
+  if (typeof domain === 'string') {
+    return checkSingleDomain(domain, db)
+  }
+  else {
+    return checkDomains(domain, db)
+  }
+}
+
+function checkSingleDomain(domain, db) {
+  return checkInDB(domain, db)
+}
+
+function checkDomains(domains, db) {
+  return checkDomainsInDB(domains, db)
+}
+
+function checkInDB(domain, db) {
+  try {
+    const stmt = db.prepare('SELECT * FROM green_presenting WHERE url = ?')
+    return !!stmt.get(domain).green
+  } finally {
+    if (db) {
+      db.close()
+    }
+  }
+}
+
+
+function greenDomainsFromResults(greenResults) {
+  const entries = Object.entries(greenResults);
+  let greenEntries = entries.filter(function ([key, val]) {
+    return val.green
+  });
+
+  return greenEntries.map(function ([key, val]) {
+    return val.url
+  });
+}
+
+function checkDomainsInDB(domains, db) {
+
+  try {
+    const stmt = db.prepare(`SELECT * FROM green_presenting WHERE url in (${getQ(domains)})`)
+
+    res = stmt.all(domains)
+
+    return greenDomainsFromResults(res)
+
+  } finally {
+    if (db) {
+      db.close()
+    }
+  }
+}
+
+module.exports = {
+  check
+};

--- a/src/hostingDatabase.js
+++ b/src/hostingDatabase.js
@@ -64,7 +64,7 @@ function checkDomainsInDB(domains, db) {
   try {
     const stmt = db.prepare(`SELECT * FROM green_presenting WHERE url in (${getQ(domains)})`)
 
-    res = stmt.all(domains)
+    const res = stmt.all(domains)
 
     return greenDomainsFromResults(res)
 

--- a/src/hostingDatabase.js
+++ b/src/hostingDatabase.js
@@ -29,19 +29,11 @@ function check(domain, dbName) {
 
   // is it a single domain or an array of them?
   if (typeof domain === 'string') {
-    return checkSingleDomain(domain, db)
+    return checkInDB(domain, db)
   }
   else {
-    return checkDomains(domain, db)
+    return checkDomainsInDB(domain, db)
   }
-}
-
-function checkSingleDomain(domain, db) {
-  return checkInDB(domain, db)
-}
-
-function checkDomains(domains, db) {
-  return checkDomainsInDB(domains, db)
 }
 
 function checkInDB(domain, db) {

--- a/src/hostingDatabase.test.js
+++ b/src/hostingDatabase.test.js
@@ -1,18 +1,19 @@
 'use strict';
 
 const hosting = require('./hostingDatabase');
+const path = require('path');
 
 describe('hostingDatabase', function () {
  
   describe('checking a single domain with #check', function () {
     it("tries to use a local database if available ", async function () {
-      const res = await hosting.check("google.com", "../url2green.test.db")
+      const res = await hosting.check("google.com",  path.resolve(__dirname, "..", "url2green.test.db"))
       expect(res).toEqual(true)
     })
   })
   describe('implicitly checking multiple domains with #check', function () {
     it("tries to use a local database if available", async function () {
-      const res = await hosting.check(["google.com", "kochindustries.com"], "../url2green.test.db")
+      const res = await hosting.check(["google.com", "kochindustries.com"], path.resolve(__dirname, "..", "url2green.test.db"))
       expect(res).toContain("google.com")
     })
   })

--- a/src/hostingDatabase.test.js
+++ b/src/hostingDatabase.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const hosting = require('./hostingDatabase');
+
+describe('hostingDatabase', function () {
+ 
+  describe('checking a single domain with #check', function () {
+    it("tries to use a local database if available ", async function () {
+      const res = await hosting.check("google.com", "../url2green.test.db")
+      expect(res).toEqual(true)
+    })
+  })
+  describe('implicitly checking multiple domains with #check', function () {
+    it("tries to use a local database if available", async function () {
+      const res = await hosting.check(["google.com", "kochindustries.com"], "../url2green.test.db")
+      expect(res).toContain("google.com")
+    })
+  })
+});


### PR DESCRIPTION
Sorry this PR introduce a couple of changes:
* Split the the hosting in multiple files for readability
* Remove the database location in the package.json file
* You need to give path to the database file when you use it
* No fallback if the database is missing, instead you will get an error

#8