### PR TITLE
Classify CO2 with an option object.

### DIFF
--- a/src/co2.js
+++ b/src/co2.js
@@ -4,8 +4,8 @@ const url = require('url');
 const oneByte = require('./1byte.js');
 
 const KWH_PER_BYTE_IN_DC = oneByte.KWH_PER_BYTE_IN_DC;
-const KWH_PER_BYTE_FOR_NETWORK = oneByte.KWH_PER_BYTE_FOR_NETWORK
-const CO2_PER_KWH_IN_DC_GREY = oneByte.CO2_PER_KWH_IN_DC_GREY
+const KWH_PER_BYTE_FOR_NETWORK = oneByte.KWH_PER_BYTE_FOR_NETWORK;
+const CO2_PER_KWH_IN_DC_GREY = oneByte.CO2_PER_KWH_IN_DC_GREY;
 
 // this figure is from the IEA's 2018 report for a global average:
 const CO2_PER_KWH_NETWORK_GREY = 495;
@@ -23,144 +23,142 @@ const CO2_PER_KWH_NETWORK_GREY = 495;
 
 const CO2_PER_KWH_IN_DC_GREEN = 33;
 
-
-function getCO2PerByte(bytes, green) {
-  // return a CO2 figure for energy used to shift the corresponding
-  // the data transfer.
-
-  if (bytes < 1) {
-    return 0;
+class CO2 {
+  constructor(options) {
+    this.options = options;
   }
 
-  if (green) {
-    // if we have a green datacentre, use the lower figure for renewable energy
-    const Co2ForDC = bytes * KWH_PER_BYTE_IN_DC * CO2_PER_KWH_IN_DC_GREEN;
+  perByte(bytes, green) {
+    // return a CO2 figure for energy used to shift the corresponding
+    // the data transfer.
 
-    // but for the rest of the internet, we can't easily check, so assume
-    // grey for now
-    const Co2forNetwork =
-      bytes * KWH_PER_BYTE_FOR_NETWORK * CO2_PER_KWH_NETWORK_GREY;
-
-    return Co2ForDC + Co2forNetwork;
-  }
-
-  const KwHPerByte = KWH_PER_BYTE_IN_DC + KWH_PER_BYTE_FOR_NETWORK;
-  return bytes * KwHPerByte * CO2_PER_KWH_IN_DC_GREY;
-}
-
-function getCO2PerDomain(pageXray, greenDomains) {
-  const co2PerDomain = [];
-  for (let domain of Object.keys(pageXray.domains)) {
-    let co2;
-    if (greenDomains && greenDomains.indexOf(domain) > -1) {
-      co2 = getCO2PerByte(pageXray.domains[domain].transferSize, true);
-    } else {
-      co2 = getCO2PerByte(pageXray.domains[domain].transferSize);
+    if (bytes < 1) {
+      return 0;
     }
-    co2PerDomain.push({
-      domain,
-      co2,
-      transferSize: pageXray.domains[domain].transferSize
+
+    if (green) {
+      // if we have a green datacentre, use the lower figure for renewable energy
+      const Co2ForDC = bytes * KWH_PER_BYTE_IN_DC * CO2_PER_KWH_IN_DC_GREEN;
+
+      // but for the rest of the internet, we can't easily check, so assume
+      // grey for now
+      const Co2forNetwork =
+        bytes * KWH_PER_BYTE_FOR_NETWORK * CO2_PER_KWH_NETWORK_GREY;
+
+      return Co2ForDC + Co2forNetwork;
+    }
+
+    const KwHPerByte = KWH_PER_BYTE_IN_DC + KWH_PER_BYTE_FOR_NETWORK;
+    return bytes * KwHPerByte * CO2_PER_KWH_IN_DC_GREY;
+  }
+
+  perDomain(pageXray, greenDomains) {
+    const co2PerDomain = [];
+    for (let domain of Object.keys(pageXray.domains)) {
+      let co2;
+      if (greenDomains && greenDomains.indexOf(domain) > -1) {
+        co2 = this.perByte(pageXray.domains[domain].transferSize, true);
+      } else {
+        co2 = this.perByte(pageXray.domains[domain].transferSize);
+      }
+      co2PerDomain.push({
+        domain,
+        co2,
+        transferSize: pageXray.domains[domain].transferSize
+      });
+    }
+    co2PerDomain.sort(function(a, b) {
+      return b.co2 - a.co2;
     });
+
+    return co2PerDomain;
   }
-  co2PerDomain.sort(function (a, b) {
-    return b.co2 - a.co2;
-  });
 
-  return co2PerDomain;
-}
+  perPage(pageXray, green) {
+    // Accept an xray object, and if we receive a boolean as the second
+    // argument, we assume every request we make is sent to a server
+    // running on renwewable power.
 
-function getCO2perPage(pageXray, green) {
-  // Accept an xray object, and if we receive a boolean as the second
-  // argument, we assume every request we make is sent to a server
-  // running on renwewable power.
+    // if we receive an array of domains, return a number accounting the
+    // reduced CO2 from green hosted domains
 
-  // if we receive an array of domains, return a number accounting the
-  // reduced CO2 from green hosted domains
-
-  const domainCO2 = getCO2PerDomain(pageXray, green);
-  let totalCO2 = 0;
-  for (let domain of domainCO2) {
-    totalCO2 += domain.co2;
-  }
-  return totalCO2;
-}
-
-function getCO2PerContentType(pageXray, greenDomains) {
-  const co2PerContentType = {};
-  for (let asset of pageXray.assets) {
-    const domain = url.parse(asset.url).domain;
-    const transferSize = asset.transferSize;
-    const co2ForTransfer = getCO2PerByte(
-      transferSize,
-      greenDomains && greenDomains.indexOf(domain) > -1
-    );
-    const contentType = asset.type;
-    if (!co2PerContentType[contentType]) {
-      co2PerContentType[contentType] = { co2: 0, transferSize: 0 };
+    const domainCO2 = this.perDomain(pageXray, green);
+    let totalCO2 = 0;
+    for (let domain of domainCO2) {
+      totalCO2 += domain.co2;
     }
-    co2PerContentType[contentType].co2 += co2ForTransfer;
-    co2PerContentType[contentType].transferSize += transferSize;
+    return totalCO2;
   }
-  // restructure and sort
-  const all = [];
-  for (let type of Object.keys(co2PerContentType)) {
-    all.push({
-      type,
-      co2: co2PerContentType[type].co2,
-      transferSize: co2PerContentType[type].transferSize
+
+  perContentType(pageXray, greenDomains) {
+    const co2PerContentType = {};
+    for (let asset of pageXray.assets) {
+      const domain = url.parse(asset.url).domain;
+      const transferSize = asset.transferSize;
+      const co2ForTransfer = this.perByte(
+        transferSize,
+        greenDomains && greenDomains.indexOf(domain) > -1
+      );
+      const contentType = asset.type;
+      if (!co2PerContentType[contentType]) {
+        co2PerContentType[contentType] = { co2: 0, transferSize: 0 };
+      }
+      co2PerContentType[contentType].co2 += co2ForTransfer;
+      co2PerContentType[contentType].transferSize += transferSize;
+    }
+    // restructure and sort
+    const all = [];
+    for (let type of Object.keys(co2PerContentType)) {
+      all.push({
+        type,
+        co2: co2PerContentType[type].co2,
+        transferSize: co2PerContentType[type].transferSize
+      });
+    }
+    all.sort(function(a, b) {
+      return b.co2 - a.co2;
     });
+    return all;
   }
-  all.sort(function (a, b) {
-    return b.co2 - a.co2;
-  });
-  return all;
-}
 
-function dirtiestResources(pageXray, greenDomains) {
-  const allAssets = [];
-  for (let asset of pageXray.assets) {
-    const domain = url.parse(asset.url).domain;
-    const transferSize = asset.transferSize;
-    const co2ForTransfer = getCO2PerByte(
-      transferSize,
-      greenDomains && greenDomains.indexOf(domain) > -1
-    );
-    allAssets.push({ url: asset.url, co2: co2ForTransfer, transferSize });
-  }
-  allAssets.sort(function (a, b) {
-    return b.co2 - a.co2;
-  });
-
-  return allAssets.slice(0, allAssets.length > 10 ? 10 : allAssets.length);
-}
-
-function getCO2PerParty(pageXray, greenDomains) {
-  let firstParty = 0;
-  let thirdParty = 0;
-  // calculate co2 per first/third party
-  const firstPartyRegEx = pageXray.firstPartyRegEx;
-  for (let d of Object.keys(pageXray.domains)) {
-    if (!d.match(firstPartyRegEx)) {
-      thirdParty += getCO2PerByte(
-        pageXray.domains[d].transferSize,
-        greenDomains && greenDomains.indexOf(d) > -1
+  dirtiestResources(pageXray, greenDomains) {
+    const allAssets = [];
+    for (let asset of pageXray.assets) {
+      const domain = url.parse(asset.url).domain;
+      const transferSize = asset.transferSize;
+      const co2ForTransfer = this.perByte(
+        transferSize,
+        greenDomains && greenDomains.indexOf(domain) > -1
       );
-    } else {
-      firstParty += getCO2PerByte(
-        pageXray.domains[d].transferSize,
-        greenDomains && greenDomains.indexOf(d) > -1
-      );
+      allAssets.push({ url: asset.url, co2: co2ForTransfer, transferSize });
     }
+    allAssets.sort(function(a, b) {
+      return b.co2 - a.co2;
+    });
+
+    return allAssets.slice(0, allAssets.length > 10 ? 10 : allAssets.length);
   }
-  return { firstParty, thirdParty };
+
+  perParty(pageXray, greenDomains) {
+    let firstParty = 0;
+    let thirdParty = 0;
+    // calculate co2 per first/third party
+    const firstPartyRegEx = pageXray.firstPartyRegEx;
+    for (let d of Object.keys(pageXray.domains)) {
+      if (!d.match(firstPartyRegEx)) {
+        thirdParty += this.perByte(
+          pageXray.domains[d].transferSize,
+          greenDomains && greenDomains.indexOf(d) > -1
+        );
+      } else {
+        firstParty += this.perByte(
+          pageXray.domains[d].transferSize,
+          greenDomains && greenDomains.indexOf(d) > -1
+        );
+      }
+    }
+    return { firstParty, thirdParty };
+  }
 }
 
-module.exports = {
-  perByte: getCO2PerByte,
-  perDomain: getCO2PerDomain,
-  perPage: getCO2perPage,
-  perParty: getCO2PerParty,
-  perContentType: getCO2PerContentType,
-  dirtiestResources
-};
+module.exports = CO2;

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -3,13 +3,13 @@
 const fs = require('fs');
 const path = require('path');
 
-const co2 = require('./co2');
+const CO2 = require('./co2');
 const pagexray = require('pagexray');
 
 
 describe('sustainableWeb', function () {
   describe('co2', function () {
-    let har;
+    let har, co2;
     const TGWF_GREY_VALUE = 2.0484539712;
     const TGWF_GREEN_VALUE = 0.54704300112;
     const TGWF_MIXED_VALUE = 1.7485750598399998;
@@ -19,6 +19,7 @@ describe('sustainableWeb', function () {
     const MILLION_GREEN = 2.4393599999999998;
 
     beforeEach(function () {
+      co2 = new CO2();
       har = JSON.parse(fs
         .readFileSync(path.resolve(__dirname, '../data/fixtures/tgwf.har'), 'utf8'))
     });


### PR DESCRIPTION
This just an example of what it could look like. What I like about this approach is that we open up the API with a configuration object so when in the future when we have multiple algoritms to
calculate the CO2 emission, it can always be made backward compatible or you as a user can choose which one to use.

If you like it @mrchrisadams, I can do the same with the hosting APIs.