### PR TITLE
Format code using default recommended eslint settings.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "root": true,
+  "env": {
+    "node": true,
+    "es6": true,
+    "jest/globals": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
+  "plugins": ["prettier", "jest"],
+  "extends": "eslint:recommended",
+  "rules": {
+    "prettier/prettier": [
+      "error",
+      {
+      }
+    ],
+    "no-unused-vars": "off"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -618,6 +618,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -657,6 +663,40 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
     },
+    "@typescript-eslint/experimental-utils": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.21.0.tgz",
+      "integrity": "sha512-olKw9JP/XUkav4lq0I7S1mhGgONJF9rHNhKFn9wJlpfRVjNo3PPjSvybxEldvCXnvD+WAshSzqH5cEjPp9CsBA==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "2.21.0",
+        "eslint-scope": "^5.0.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.21.0.tgz",
+      "integrity": "sha512-NC/nogZNb9IK2MEFQqyDBAciOT8Lp8O3KgAfvHx2Skx6WBo+KmDqlU3R9KxHONaijfTIKtojRe3SZQyMjr3wBw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "eslint-visitor-keys": "^1.1.0",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^6.3.0",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "abab": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
@@ -686,6 +726,12 @@
           "dev": true
         }
       }
+    },
+    "acorn-jsx": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -1838,6 +1884,15 @@
       "integrity": "sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==",
       "dev": true
     },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -1951,11 +2006,283 @@
         "source-map": "~0.6.1"
       }
     },
+    "eslint": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.3",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "globals": {
+          "version": "12.3.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
+          "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "import-fresh": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
+      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "23.8.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.8.1.tgz",
+      "integrity": "sha512-OycLNqPo/2EfO6kTqnmsu1khz1gTIOxGl3ThIVwL5/oycDF4pm5uNDyvFelNLdpr4COUuM8PVi3963NEG1Efpw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^2.5.0"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
+      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "dev": true
+    },
+    "espree": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.1.0",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "esquery": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
     },
     "estraverse": {
       "version": "4.3.0",
@@ -2186,6 +2513,12 @@
       "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2224,6 +2557,15 @@
         }
       }
     },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2242,6 +2584,34 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -2302,6 +2672,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -2312,6 +2688,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-stream": {
@@ -2356,6 +2738,15 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "global-dirs": {
@@ -2604,6 +2995,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
     },
     "import-fresh": {
       "version": "2.0.0",
@@ -2996,6 +3393,12 @@
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3007,6 +3410,15 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-installed-globally": {
       "version": "0.3.1",
@@ -3766,6 +4178,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json-stringify-safe": {
@@ -5044,6 +5462,15 @@
         "minimist": "1.2.0"
       }
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -5188,6 +5615,21 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
     "pretty-format": {
       "version": "25.1.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.1.0.tgz",
@@ -5199,6 +5641,12 @@
         "ansi-styles": "^4.0.0",
         "react-is": "^16.12.0"
       }
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
     },
     "prompts": {
       "version": "2.3.1",
@@ -5352,6 +5800,12 @@
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
       }
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
     },
     "registry-auth-token": {
       "version": "4.1.1",
@@ -6330,6 +6784,78 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+          "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "astral-regex": "^1.0.0",
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
     "tar": {
       "version": "4.4.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
@@ -6469,6 +6995,12 @@
         "minimatch": "^3.0.4"
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
     "throat": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
@@ -6594,6 +7126,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
       "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
+    },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -6865,6 +7406,12 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
     "v8-to-istanbul": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.2.tgz",
@@ -7086,6 +7633,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Work out the co2 of your digital services",
   "main": "src/index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "keywords": [
     "sustainability",
@@ -20,7 +22,12 @@
   "devDependencies": {
     "np": "^5.2.1",
     "pagexray": "^2.5.9",
-    "jest": "25.1.0"
+    "jest": "25.1.0",
+    "eslint": "6.8.0",
+    "prettier": "1.19.1",
+    "eslint-config-prettier": "6.10.0",
+    "eslint-plugin-prettier": "3.1.2",
+    "eslint-plugin-jest": "23.8.1"
   },
   "np": {
     "yarn": false

--- a/src/1byte.js
+++ b/src/1byte.js
@@ -1,4 +1,3 @@
-
 // Use the 1byte model for now from the Shift Project, and assume a US grid mix figure they use of around 519 g co2 for the time being. It's lower for Europe, and in particular, France, but for v1, we don't include this
 const CO2_PER_KWH_IN_DC_GREY = 519;
 
@@ -19,10 +18,10 @@ const KWH_PER_BYTE_IN_DC = 0.00000000072;
 // Pull requests gratefully accepted
 const KWH_PER_BYTE_FOR_NETWORK = 0.00000000488;
 
-const KWH_PER_BYTE_FOR_DEVICES = 0.00000000013
+const KWH_PER_BYTE_FOR_DEVICES = 0.00000000013;
 module.exports = {
   KWH_PER_BYTE_IN_DC,
   KWH_PER_BYTE_FOR_NETWORK,
   KWH_PER_BYTE_FOR_DEVICES,
   CO2_PER_KWH_IN_DC_GREY
-}
+};

--- a/src/co2.js
+++ b/src/co2.js
@@ -1,11 +1,11 @@
-'use strict';
+"use strict";
 
-const url = require('url');
-const oneByte = require('./1byte.js');
+const url = require("url");
+const oneByte = require("./1byte.js");
 
 const KWH_PER_BYTE_IN_DC = oneByte.KWH_PER_BYTE_IN_DC;
-const KWH_PER_BYTE_FOR_NETWORK = oneByte.KWH_PER_BYTE_FOR_NETWORK
-const CO2_PER_KWH_IN_DC_GREY = oneByte.CO2_PER_KWH_IN_DC_GREY
+const KWH_PER_BYTE_FOR_NETWORK = oneByte.KWH_PER_BYTE_FOR_NETWORK;
+const CO2_PER_KWH_IN_DC_GREY = oneByte.CO2_PER_KWH_IN_DC_GREY;
 
 // this figure is from the IEA's 2018 report for a global average:
 const CO2_PER_KWH_NETWORK_GREY = 495;
@@ -22,7 +22,6 @@ const CO2_PER_KWH_NETWORK_GREY = 495;
 // https://en.wikipedia.org/wiki/Life-cycle_greenhouse-gas_emissions_of_energy_sources
 
 const CO2_PER_KWH_IN_DC_GREEN = 33;
-
 
 function getCO2PerByte(bytes, green) {
   // return a CO2 figure for energy used to shift the corresponding
@@ -63,7 +62,7 @@ function getCO2PerDomain(pageXray, greenDomains) {
       transferSize: pageXray.domains[domain].transferSize
     });
   }
-  co2PerDomain.sort(function (a, b) {
+  co2PerDomain.sort(function(a, b) {
     return b.co2 - a.co2;
   });
 
@@ -111,7 +110,7 @@ function getCO2PerContentType(pageXray, greenDomains) {
       transferSize: co2PerContentType[type].transferSize
     });
   }
-  all.sort(function (a, b) {
+  all.sort(function(a, b) {
     return b.co2 - a.co2;
   });
   return all;
@@ -128,7 +127,7 @@ function dirtiestResources(pageXray, greenDomains) {
     );
     allAssets.push({ url: asset.url, co2: co2ForTransfer, transferSize });
   }
-  allAssets.sort(function (a, b) {
+  allAssets.sort(function(a, b) {
     return b.co2 - a.co2;
   });
 

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -1,132 +1,133 @@
-'use strict';
+"use strict";
 
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-const co2 = require('./co2');
-const pagexray = require('pagexray');
+const co2 = require("./co2");
+const pagexray = require("pagexray");
 
-
-describe('sustainableWeb', function () {
-  describe('co2', function () {
+describe("sustainableWeb", function() {
+  describe("co2", function() {
     let har;
     const TGWF_GREY_VALUE = 2.0484539712;
-    const TGWF_GREEN_VALUE = 0.54704300112;
+    // const TGWF_GREEN_VALUE = 0.54704300112;
     const TGWF_MIXED_VALUE = 1.7485750598399998;
 
     const MILLION = 1000000;
     const MILLION_GREY = 2.9064;
     const MILLION_GREEN = 2.4393599999999998;
 
-    beforeEach(function () {
-      har = JSON.parse(fs
-        .readFileSync(path.resolve(__dirname, '../data/fixtures/tgwf.har'), 'utf8'))
+    beforeEach(function() {
+      har = JSON.parse(
+        fs.readFileSync(
+          path.resolve(__dirname, "../data/fixtures/tgwf.har"),
+          "utf8"
+        )
+      );
     });
 
-    describe('perByte', function () {
-
-
-      it("returns a CO2 number for data transfer using 'grey' power", function () {
+    describe("perByte", function() {
+      it("returns a CO2 number for data transfer using 'grey' power", function() {
         expect(co2.perByte(MILLION)).toBe(MILLION_GREY);
       });
 
-      it("returns a lower CO2 number for data transfer from domains using entirely 'green' power", function () {
+      it("returns a lower CO2 number for data transfer from domains using entirely 'green' power", function() {
         expect(co2.perByte(MILLION, false)).toBe(MILLION_GREY);
         expect(co2.perByte(MILLION, true)).toBe(MILLION_GREEN);
       });
     });
 
-    describe('perPage', function () {
-      it('returns CO2 for total transfer for page', function () {
+    describe("perPage", function() {
+      it("returns CO2 for total transfer for page", function() {
         const pages = pagexray.convert(har);
         const pageXrayRun = pages[0];
 
         expect(co2.perPage(pageXrayRun)).toBe(TGWF_GREY_VALUE);
       });
-      it('returns lower CO2 for page served from green site', function () {
+      it("returns lower CO2 for page served from green site", function() {
         const pages = pagexray.convert(har);
         const pageXrayRun = pages[0];
         let green = [
-          'www.thegreenwebfoundation.org',
-          'fonts.googleapis.com',
-          'ajax.googleapis.com',
-          'assets.digitalclimatestrike.net',
-          'cdnjs.cloudflare.com',
-          'graphite.thegreenwebfoundation.org',
-          'analytics.thegreenwebfoundation.org',
-          'fonts.gstatic.com',
-          'api.thegreenwebfoundation.org'
+          "www.thegreenwebfoundation.org",
+          "fonts.googleapis.com",
+          "ajax.googleapis.com",
+          "assets.digitalclimatestrike.net",
+          "cdnjs.cloudflare.com",
+          "graphite.thegreenwebfoundation.org",
+          "analytics.thegreenwebfoundation.org",
+          "fonts.gstatic.com",
+          "api.thegreenwebfoundation.org"
         ];
         expect(co2.perPage(pageXrayRun, green)).toBeLessThan(TGWF_GREY_VALUE);
       });
-      it('returns a lower CO2 number where *some* domains use green power', function () {
+      it("returns a lower CO2 number where *some* domains use green power", function() {
         const pages = pagexray.convert(har);
         const pageXrayRun = pages[0];
         // green can be true, or a array containing entries
         let green = [
-          'www.thegreenwebfoundation.org',
-          'fonts.googleapis.com',
-          'ajax.googleapis.com',
-          'assets.digitalclimatestrike.net',
-          'cdnjs.cloudflare.com',
-          'graphite.thegreenwebfoundation.org',
-          'analytics.thegreenwebfoundation.org',
-          'fonts.gstatic.com',
-          'api.thegreenwebfoundation.org'
+          "www.thegreenwebfoundation.org",
+          "fonts.googleapis.com",
+          "ajax.googleapis.com",
+          "assets.digitalclimatestrike.net",
+          "cdnjs.cloudflare.com",
+          "graphite.thegreenwebfoundation.org",
+          "analytics.thegreenwebfoundation.org",
+          "fonts.gstatic.com",
+          "api.thegreenwebfoundation.org"
         ];
         expect(co2.perPage(pageXrayRun, green)).toBe(TGWF_MIXED_VALUE);
       });
     });
-    describe('perDomain', function () {
-      it('shows object listing Co2 for each domain', function () {
+    describe("perDomain", function() {
+      it("shows object listing Co2 for each domain", function() {
         const pages = pagexray.convert(har);
         const pageXrayRun = pages[0];
         const res = co2.perDomain(pageXrayRun);
 
         const domains = [
-          'thegreenwebfoundation.org',
-          'www.thegreenwebfoundation.org',
-          'maxcdn.bootstrapcdn.com',
-          'fonts.googleapis.com',
-          'ajax.googleapis.com',
-          'assets.digitalclimatestrike.net',
-          'cdnjs.cloudflare.com',
-          'graphite.thegreenwebfoundation.org',
-          'analytics.thegreenwebfoundation.org',
-          'fonts.gstatic.com',
-          'api.thegreenwebfoundation.org'
+          "thegreenwebfoundation.org",
+          "www.thegreenwebfoundation.org",
+          "maxcdn.bootstrapcdn.com",
+          "fonts.googleapis.com",
+          "ajax.googleapis.com",
+          "assets.digitalclimatestrike.net",
+          "cdnjs.cloudflare.com",
+          "graphite.thegreenwebfoundation.org",
+          "analytics.thegreenwebfoundation.org",
+          "fonts.gstatic.com",
+          "api.thegreenwebfoundation.org"
         ];
 
         for (let obj of res) {
           expect(domains.indexOf(obj.domain)).toBeGreaterThan(-1);
-          expect(typeof obj.co2).toBe('number');
-        };
+          expect(typeof obj.co2).toBe("number");
+        }
       });
-      it('shows lower Co2 for green domains', function () {
+      it("shows lower Co2 for green domains", function() {
         const pages = pagexray.convert(har);
         const pageXrayRun = pages[0];
 
         const greenDomains = [
-          'www.thegreenwebfoundation.org',
-          'fonts.googleapis.com',
-          'ajax.googleapis.com',
-          'assets.digitalclimatestrike.net',
-          'cdnjs.cloudflare.com',
-          'graphite.thegreenwebfoundation.org',
-          'analytics.thegreenwebfoundation.org',
-          'fonts.gstatic.com',
-          'api.thegreenwebfoundation.org'
+          "www.thegreenwebfoundation.org",
+          "fonts.googleapis.com",
+          "ajax.googleapis.com",
+          "assets.digitalclimatestrike.net",
+          "cdnjs.cloudflare.com",
+          "graphite.thegreenwebfoundation.org",
+          "analytics.thegreenwebfoundation.org",
+          "fonts.gstatic.com",
+          "api.thegreenwebfoundation.org"
         ];
         const res = co2.perDomain(pageXrayRun);
         const resWithGreen = co2.perDomain(pageXrayRun, greenDomains);
 
         for (let obj of res) {
-          expect(typeof obj.co2).toBe('number');
-        };
+          expect(typeof obj.co2).toBe("number");
+        }
         for (let obj of greenDomains) {
-          let index = 0
+          let index = 0;
           expect(resWithGreen[index].co2).toBeLessThan(res[index].co2);
-          index++
+          index++;
         }
       });
     });
@@ -138,4 +139,3 @@ describe('sustainableWeb', function () {
     // });
   });
 });
-

--- a/src/green-byte.js
+++ b/src/green-byte.js
@@ -1,4 +1,3 @@
-
 // PLEASE DO NOT USE THIS MODEL YET FOR CALCS
 
 const CO2_PER_KWH_IN_DC_GREY = 519;
@@ -19,10 +18,9 @@ const KWH_PER_BYTE_FOR_DEVICES = 0.00000000055;
 //  1. the usage for devices (which is small proportion of the energy use)
 //  2. the *making* the device, which is comparitively high.
 
-
 module.exports = {
   KWH_PER_BYTE_IN_DC,
   KWH_PER_BYTE_FOR_NETWORK,
   KWH_PER_BYTE_FOR_DEVICES,
   CO2_PER_KWH_IN_DC_GREY
-}
+};

--- a/src/hosting.js
+++ b/src/hosting.js
@@ -1,35 +1,35 @@
-'use strict';
+"use strict";
 
-const log = require('debug')('tgwf:hosting');
-const hostingAPI = require('./hostingAPI');
-const hostingDatabase = require('./hostingDatabase');
+// const log = require("debug")("tgwf:hosting");
+const hostingAPI = require("./hostingAPI");
+const hostingDatabase = require("./hostingDatabase");
 
 function check(domain, dbName) {
   if (dbName) {
-    return hostingDatabase.check(domain, dbName)
+    return hostingDatabase.check(domain, dbName);
   } else {
     return hostingAPI.check(domain);
   }
 }
 
 function greenDomainsFromResults(greenResults) {
-  const entries = Object.entries(greenResults)
-  let greenEntries = entries.filter(function ([key, val]) {
-    return val.green
+  const entries = Object.entries(greenResults);
+  let greenEntries = entries.filter(function([key, val]) {
+    return val.green;
   });
 
-  return greenEntries.map(function ([key, val]) {
+  return greenEntries.map(function([key, val]) {
     return val.url;
   });
 }
 
 async function checkPage(pageXray) {
-  const domains = Object.keys(pageXray.domains)
-  return check(domains)
+  const domains = Object.keys(pageXray.domains);
+  return check(domains);
 }
 
 module.exports = {
   check,
   checkPage,
-  greenDomains: greenDomainsFromResults,
+  greenDomains: greenDomainsFromResults
 };

--- a/src/hosting.test.js
+++ b/src/hosting.test.js
@@ -1,41 +1,44 @@
-'use strict';
+"use strict";
 
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-const hosting = require('./hosting');
-const pagexray = require('pagexray');
+const hosting = require("./hosting");
+const pagexray = require("pagexray");
 
-describe('hosting', function () {
+describe("hosting", function() {
   let har;
-  beforeEach(function () {
-    har = JSON.parse(fs
-      .readFileSync(path.resolve(__dirname, '../data/fixtures/tgwf.har'), 'utf8'))
+  beforeEach(function() {
+    har = JSON.parse(
+      fs.readFileSync(
+        path.resolve(__dirname, "../data/fixtures/tgwf.har"),
+        "utf8"
+      )
+    );
   });
-  describe('checking all domains on a page object with #checkPage ', function () {
-    it('it returns a list of green domains, when passed a page object', async function () {
+  describe("checking all domains on a page object with #checkPage ", function() {
+    it("it returns a list of green domains, when passed a page object", async function() {
       const pages = pagexray.convert(har);
       const pageXrayRun = pages[0];
 
       // TODO find a way to not hit the API each time
       const greenDomains = await hosting.checkPage(pageXrayRun);
 
-      expect(greenDomains)
-        .toHaveLength(10);
+      expect(greenDomains).toHaveLength(10);
 
       const expectedGreendomains = [
-        'thegreenwebfoundation.org',
-        'www.thegreenwebfoundation.org',
-        'fonts.googleapis.com',
-        'ajax.googleapis.com',
-        'assets.digitalclimatestrike.net',
-        'cdnjs.cloudflare.com',
-        'graphite.thegreenwebfoundation.org',
-        'analytics.thegreenwebfoundation.org',
-        'fonts.gstatic.com',
-        'api.thegreenwebfoundation.org'
+        "thegreenwebfoundation.org",
+        "www.thegreenwebfoundation.org",
+        "fonts.googleapis.com",
+        "ajax.googleapis.com",
+        "assets.digitalclimatestrike.net",
+        "cdnjs.cloudflare.com",
+        "graphite.thegreenwebfoundation.org",
+        "analytics.thegreenwebfoundation.org",
+        "fonts.gstatic.com",
+        "api.thegreenwebfoundation.org"
       ];
-      greenDomains.forEach(function (dom) {
+      greenDomains.forEach(function(dom) {
         expect(expectedGreendomains).toContain(dom);
       });
     });
@@ -43,35 +46,43 @@ describe('hosting', function () {
     //   'it returns an empty list, when passed a page object with no green domains'
     // );
   });
-  describe('checking a single domain with #check', function () {
-    it("tries to use a local database", async function () {
-      const res = await hosting.check("google.com", path.resolve(__dirname, "..", "url2green.test.db"))
-      expect(res).toEqual(true)
-    })
-    it("use the API instead", async function () {
-      const res = await hosting.check("google.com")
-      expect(res).toEqual(true)
-    })
-
-  })
-  describe('implicitly checking multiple domains with #check', function () {
-    it("tries to use a local database if available", async function () {
-      const res = await hosting.check(["google.com", "kochindustries.com"], path.resolve(__dirname, "..", "url2green.test.db"))
-      expect(res).toContain("google.com")
-    })
-    it("Use the API", async function () {
-      const res = await hosting.check(["google.com", "kochindustries.com"])
-      expect(res).toContain("google.com")
-    })
-  })
-  describe('explicitly checking multiple domains with #checkMulti', function () {
-    it("tries to use a local database if available", async function () {
-      const res = await hosting.check(["google.com", "kochindustries.com"], path.resolve(__dirname, "..", "url2green.test.db"))
-      expect(res).toContain("google.com")
-    })
-    it("use the API", async function () {
-      const res = await hosting.check(["google.com", "kochindustries.com"])
-      expect(res).toContain("google.com")
-    })
-  })
+  describe("checking a single domain with #check", function() {
+    it("tries to use a local database", async function() {
+      const res = await hosting.check(
+        "google.com",
+        path.resolve(__dirname, "..", "url2green.test.db")
+      );
+      expect(res).toEqual(true);
+    });
+    it("use the API instead", async function() {
+      const res = await hosting.check("google.com");
+      expect(res).toEqual(true);
+    });
+  });
+  describe("implicitly checking multiple domains with #check", function() {
+    it("tries to use a local database if available", async function() {
+      const res = await hosting.check(
+        ["google.com", "kochindustries.com"],
+        path.resolve(__dirname, "..", "url2green.test.db")
+      );
+      expect(res).toContain("google.com");
+    });
+    it("Use the API", async function() {
+      const res = await hosting.check(["google.com", "kochindustries.com"]);
+      expect(res).toContain("google.com");
+    });
+  });
+  describe("explicitly checking multiple domains with #checkMulti", function() {
+    it("tries to use a local database if available", async function() {
+      const res = await hosting.check(
+        ["google.com", "kochindustries.com"],
+        path.resolve(__dirname, "..", "url2green.test.db")
+      );
+      expect(res).toContain("google.com");
+    });
+    it("use the API", async function() {
+      const res = await hosting.check(["google.com", "kochindustries.com"]);
+      expect(res).toContain("google.com");
+    });
+  });
 });

--- a/src/hostingAPI.js
+++ b/src/hostingAPI.js
@@ -1,25 +1,22 @@
-'use strict';
+"use strict";
 
-const log = require('debug')('tgwf:hostingAPI');
-const https = require('https');
+const log = require("debug")("tgwf:hostingAPI");
+const https = require("https");
 
 function check(domain) {
   // is it a single domain or an array of them?
-  if (typeof domain === 'string') {
-    return checkAgainstAPI(domain)
-  }
-  else {
-    return checkDomainsAgainstAPI(domain)
+  if (typeof domain === "string") {
+    return checkAgainstAPI(domain);
+  } else {
+    return checkDomainsAgainstAPI(domain);
   }
 }
 
 async function checkAgainstAPI(domain) {
   const res = JSON.parse(
-    await getBody(
-      `https://api.thegreenwebfoundation.org/greencheck/${domain}`
-    )
+    await getBody(`https://api.thegreenwebfoundation.org/greencheck/${domain}`)
   );
-  return res.green
+  return res.green;
 }
 
 async function checkDomainsAgainstAPI(domains) {
@@ -32,8 +29,7 @@ async function checkDomainsAgainstAPI(domains) {
       )
     );
 
-    return greenDomainsFromResults(allGreenCheckResults)
-
+    return greenDomainsFromResults(allGreenCheckResults);
   } catch (e) {
     return [];
   }
@@ -41,24 +37,23 @@ async function checkDomainsAgainstAPI(domains) {
 
 function greenDomainsFromResults(greenResults) {
   const entries = Object.entries(greenResults);
-  let greenEntries = entries.filter(function ([key, val]) {
+  let greenEntries = entries.filter(function([key, val]) {
     return val.green;
   });
 
-  return greenEntries.map(function ([key, val]) {
+  return greenEntries.map(function([key, val]) {
     return val.url;
   });
 }
 
-
 async function getBody(url) {
   // Return new promise
-  return new Promise(function (resolve, reject) {
+  return new Promise(function(resolve, reject) {
     // Do async job
-    const req = https.get(url, function (res) {
+    const req = https.get(url, function(res) {
       if (res.statusCode < 200 || res.statusCode >= 300) {
         log(
-          'Could not get info from the Green Web Foundation API, %s for %s',
+          "Could not get info from the Green Web Foundation API, %s for %s",
           res.statusCode,
           url
         );
@@ -66,11 +61,11 @@ async function getBody(url) {
       }
       const data = [];
 
-      res.on('data', chunk => {
+      res.on("data", chunk => {
         data.push(chunk);
       });
 
-      res.on('end', () => resolve(Buffer.concat(data).toString()));
+      res.on("end", () => resolve(Buffer.concat(data).toString()));
     });
     req.end();
   });

--- a/src/hostingAPI.test.js
+++ b/src/hostingAPI.test.js
@@ -1,19 +1,18 @@
-'use strict';
+"use strict";
 
-const hosting = require('./hostingAPI');
+const hosting = require("./hostingAPI");
 
-describe('hostingAPI', function () {
-  describe('checking a single domain with #check', function () {
-    it("using the API", async function () {
-      const res = await hosting.check("google.com")
-      expect(res).toEqual(true)
-    })
-
-  })
-  describe('implicitly checking multiple domains with #check', function () {
-    it("using the API", async function () {
-      const res = await hosting.check(["google.com", "kochindustries.com"])
-      expect(res).toContain("google.com")
-    })
-  })
+describe("hostingAPI", function() {
+  describe("checking a single domain with #check", function() {
+    it("using the API", async function() {
+      const res = await hosting.check("google.com");
+      expect(res).toEqual(true);
+    });
+  });
+  describe("implicitly checking multiple domains with #check", function() {
+    it("using the API", async function() {
+      const res = await hosting.check(["google.com", "kochindustries.com"]);
+      expect(res).toContain("google.com");
+    });
+  });
 });

--- a/src/hostingDatabase.js
+++ b/src/hostingDatabase.js
@@ -1,76 +1,76 @@
-'use strict';
+"use strict";
 
-const log = require('debug')('tgwf:hostingDatabase');
-const Database = require('better-sqlite3');
+const log = require("debug")("tgwf:hostingDatabase");
+const Database = require("better-sqlite3");
 
 function getQ(domains) {
   const q = [];
   for (let domain of domains) {
-    q.push('?')
+    q.push("?");
   }
-  return q.join(',');
+  return q.join(",");
 }
 
 function getDatabase(databaseFullPathAndName) {
-  log(`looking for db at ${databaseFullPathAndName}`)
-  return new Database(databaseFullPathAndName, { readonly: true, fileMustExist: true });
+  log(`looking for db at ${databaseFullPathAndName}`);
+  return new Database(databaseFullPathAndName, {
+    readonly: true,
+    fileMustExist: true
+  });
 }
 
 function check(domain, dbName) {
   let db;
 
   try {
-    db = getDatabase(dbName)
-  }
-  catch (SqliteError) {
-    log(`couldn't find SQlite database at path: ${dbName}`)
-    throw SqliteError
+    db = getDatabase(dbName);
+  } catch (SqliteError) {
+    log(`couldn't find SQlite database at path: ${dbName}`);
+    throw SqliteError;
   }
 
   // is it a single domain or an array of them?
-  if (typeof domain === 'string') {
-    return checkInDB(domain, db)
-  }
-  else {
-    return checkDomainsInDB(domain, db)
+  if (typeof domain === "string") {
+    return checkInDB(domain, db);
+  } else {
+    return checkDomainsInDB(domain, db);
   }
 }
 
 function checkInDB(domain, db) {
   try {
-    const stmt = db.prepare('SELECT * FROM green_presenting WHERE url = ?')
-    return !!stmt.get(domain).green
+    const stmt = db.prepare("SELECT * FROM green_presenting WHERE url = ?");
+    return !!stmt.get(domain).green;
   } finally {
     if (db) {
-      db.close()
+      db.close();
     }
   }
 }
 
-
 function greenDomainsFromResults(greenResults) {
   const entries = Object.entries(greenResults);
-  let greenEntries = entries.filter(function ([key, val]) {
-    return val.green
+  let greenEntries = entries.filter(function([key, val]) {
+    return val.green;
   });
 
-  return greenEntries.map(function ([key, val]) {
-    return val.url
+  return greenEntries.map(function([key, val]) {
+    return val.url;
   });
 }
 
 function checkDomainsInDB(domains, db) {
-
   try {
-    const stmt = db.prepare(`SELECT * FROM green_presenting WHERE url in (${getQ(domains)})`)
+    const stmt = db.prepare(
+      `SELECT * FROM green_presenting WHERE url in (${getQ(domains)})`
+    );
 
-    const res = stmt.all(domains)
+    const res = stmt.all(domains);
 
-    return greenDomainsFromResults(res)
-
+    return greenDomainsFromResults(res);
   } finally {
     if (db) {
-      db.close()
+      db.close();
     }
   }
 }

--- a/src/hostingDatabase.test.js
+++ b/src/hostingDatabase.test.js
@@ -1,20 +1,25 @@
-'use strict';
+"use strict";
 
-const hosting = require('./hostingDatabase');
-const path = require('path');
+const hosting = require("./hostingDatabase");
+const path = require("path");
 
-describe('hostingDatabase', function () {
- 
-  describe('checking a single domain with #check', function () {
-    it("tries to use a local database if available ", async function () {
-      const res = await hosting.check("google.com",  path.resolve(__dirname, "..", "url2green.test.db"))
-      expect(res).toEqual(true)
-    })
-  })
-  describe('implicitly checking multiple domains with #check', function () {
-    it("tries to use a local database if available", async function () {
-      const res = await hosting.check(["google.com", "kochindustries.com"], path.resolve(__dirname, "..", "url2green.test.db"))
-      expect(res).toContain("google.com")
-    })
-  })
+describe("hostingDatabase", function() {
+  describe("checking a single domain with #check", function() {
+    it("tries to use a local database if available ", async function() {
+      const res = await hosting.check(
+        "google.com",
+        path.resolve(__dirname, "..", "url2green.test.db")
+      );
+      expect(res).toEqual(true);
+    });
+  });
+  describe("implicitly checking multiple domains with #check", function() {
+    it("tries to use a local database if available", async function() {
+      const res = await hosting.check(
+        ["google.com", "kochindustries.com"],
+        path.resolve(__dirname, "..", "url2green.test.db")
+      );
+      expect(res).toContain("google.com");
+    });
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-const co2 = require("./co2")
-const hosting = require("./hosting")
+const co2 = require("./co2");
+const hosting = require("./hosting");
 
 module.exports = {
   co2,
   hosting
-}
+};


### PR DESCRIPTION
Ok you need to merge this manually since my class change went through is it ok?

I've set it up using default eslint settings, only exception is unused variables, I turned that rule off for now thinking we can cleanup the code later. In VSCode the setting Is automatically picked, lets see if we can make it happened your editor too,

`npm run lint` runs the tests, `npm run lint:fix` fixes the ones that can be automatically fixed. Then we can add the check to Travis + you can also make pre commit hook that either checks or auto format fit lint:fix depending on how you wanna work.