### PR TITLE
Update test structure to support both models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+
 # [0.9.0] - 2022-03-28
 
-- Added newly implemented Sustainable Web Design model [thaks @dryden!]
+### Added
+
+- Added newly implemented Sustainable Web Design model [thanks @dryden!]
 - Added new readme page for using both emissions models
 - Added new source of data to the Sustainable Web Design model from Ember Climate.
+### Changed
+
+- Changed the CO2 class to accept either the One Byte model or the Sustainable Web Design model
+### Fixed
+
 - Fixed various typos.
 
 # [0.8.0] - 2021-11-28
@@ -28,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The 1bye model will give different numbers now. It's mentioned in `#fixed` but it's worth repeating.
+- The 1byte model will give different numbers now. It's mentioned in `#fixed` but it's worth repeating.
 
 ## [0.7.0] - 2021-11-28
 
@@ -66,9 +75,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update README
-- Update the emissions figured for green energy after further research on methodology with @@JamieBeevor
-- Incorproate class based CO2 models from @soulgalore
+- Updated README
+- Updated the emissions figured for green energy after further research on methodology with @@JamieBeevor
+- Incorporated class based CO2 models from @soulgalore
 - Credit contributors
 
 
@@ -88,7 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-Add the (currently unused) green byte model.
+Added the (currently unused) green byte model.
 
 ### Changed
 

--- a/src/1byte.js
+++ b/src/1byte.js
@@ -1,6 +1,17 @@
 // Use the 1byte model for now from the Shift Project, and assume a US grid mix figure they use of around 519 g co2 for the time being. It's lower for Europe, and in particular, France, but for v1, we don't include this
 const CO2_PER_KWH_IN_DC_GREY = 519;
 
+// this figure is from the IEA's 2018 report for a global average:
+const CO2_PER_KWH_NETWORK_GREY = 475;
+
+// TODO - these figures need to be updated, as the figures for green
+// shouldn't really be zero now we know that carbon intensity figures
+// for renewables still usually include the life cycle emissions
+const CO2_PER_KWH_IN_DC_GREEN = 0;
+
+
+
+
 // the 1 byte model gives figures for energy usage for:
 
 // datacentres
@@ -28,9 +39,38 @@ const KWH_PER_BYTE_FOR_NETWORK =
   (FIXED_NETWORK_WIRED + FIXED_NETWORK_WIFI + FOUR_G_MOBILE) / 3;
 
 const KWH_PER_BYTE_FOR_DEVICES = 1.3e-10;
+
+class OneByte {
+  constructor(options) {
+    this.options = options
+
+    this.KWH_PER_BYTE_FOR_NETWORK = KWH_PER_BYTE_FOR_NETWORK
+  }
+
+  perByte(bytes, green) {
+
+    if (bytes < 1) {
+      return 0;
+    }
+
+    if (green) {
+      // if we have a green datacentre, use the lower figure for renewable energy
+      const Co2ForDC = bytes * KWH_PER_BYTE_IN_DC * CO2_PER_KWH_IN_DC_GREEN;
+
+      // but for the worest of the internet, we can't easily check, so assume
+      // grey for now
+      const Co2forNetwork =
+        bytes * KWH_PER_BYTE_FOR_NETWORK * CO2_PER_KWH_NETWORK_GREY;
+
+      return Co2ForDC + Co2forNetwork;
+    }
+
+    const KwHPerByte = KWH_PER_BYTE_IN_DC + KWH_PER_BYTE_FOR_NETWORK;
+    return bytes * KwHPerByte * CO2_PER_KWH_IN_DC_GREY;
+  }
+}
+
+
 module.exports = {
-  KWH_PER_BYTE_IN_DC,
-  KWH_PER_BYTE_FOR_NETWORK,
-  KWH_PER_BYTE_FOR_DEVICES,
-  CO2_PER_KWH_IN_DC_GREY,
+  OneByte
 };

--- a/src/1byte.js
+++ b/src/1byte.js
@@ -9,9 +9,6 @@ const CO2_PER_KWH_NETWORK_GREY = 475;
 // for renewables still usually include the life cycle emissions
 const CO2_PER_KWH_IN_DC_GREEN = 0;
 
-
-
-
 // the 1 byte model gives figures for energy usage for:
 
 // datacentres
@@ -42,13 +39,12 @@ const KWH_PER_BYTE_FOR_DEVICES = 1.3e-10;
 
 class OneByte {
   constructor(options) {
-    this.options = options
+    this.options = options;
 
-    this.KWH_PER_BYTE_FOR_NETWORK = KWH_PER_BYTE_FOR_NETWORK
+    this.KWH_PER_BYTE_FOR_NETWORK = KWH_PER_BYTE_FOR_NETWORK;
   }
 
   perByte(bytes, green) {
-
     if (bytes < 1) {
       return 0;
     }
@@ -70,7 +66,6 @@ class OneByte {
   }
 }
 
-
 module.exports = {
-  OneByte
+  OneByte,
 };

--- a/src/1byte.test.js
+++ b/src/1byte.test.js
@@ -9,7 +9,7 @@ describe("onebyte", () => {
       // we have a recurring 333333 afterwards
       // 4.88e-10 is the same as 0.000000000488
       const expected_val = (0.000000000488).toFixed(12);
-      const instance = new oneByte.OneByte()
+      const instance = new oneByte.OneByte();
 
       expect(instance.KWH_PER_BYTE_FOR_NETWORK.toFixed(12)).toBe(expected_val);
     });

--- a/src/1byte.test.js
+++ b/src/1byte.test.js
@@ -2,15 +2,16 @@
 
 const oneByte = require("./1byte");
 
-describe("onebyte", function () {
-  describe("perByte", function () {
-    it.only("returns a simple average of the different networks", function () {
+describe("onebyte", () => {
+  describe("perByte", () => {
+    it.only("returns a simple average of the different networks", () => {
       // we limit this to 12 figures with toFixed(12), because
       // we have a recurring 333333 afterwards
       // 4.88e-10 is the same as 0.000000000488
       const expected_val = (0.000000000488).toFixed(12);
+      const instance = new oneByte.OneByte()
 
-      expect(oneByte.KWH_PER_BYTE_FOR_NETWORK.toFixed(12)).toBe(expected_val);
+      expect(instance.KWH_PER_BYTE_FOR_NETWORK.toFixed(12)).toBe(expected_val);
     });
   });
 });

--- a/src/co2.js
+++ b/src/co2.js
@@ -8,18 +8,17 @@ class CO2 {
     this.options = options;
 
     // default model
-    this.model = new onebyte.OneByte()
+    this.model = new onebyte.OneByte();
 
     if (options) {
       this.model = new options.model();
     }
-
   }
 
   // return a CO2 figure for energy used to shift the corresponding
   // the data transfer.
   perByte(bytes, green) {
-    return this.model.perByte(bytes, green)
+    return this.model.perByte(bytes, green);
   }
 
   perDomain(pageXray, greenDomains) {

--- a/src/co2.js
+++ b/src/co2.js
@@ -1,48 +1,25 @@
 "use strict";
 
 const url = require("url");
-const oneByte = require("./1byte.js");
-
-const KWH_PER_BYTE_IN_DC = oneByte.KWH_PER_BYTE_IN_DC;
-const KWH_PER_BYTE_FOR_NETWORK = oneByte.KWH_PER_BYTE_FOR_NETWORK;
-const CO2_PER_KWH_IN_DC_GREY = oneByte.CO2_PER_KWH_IN_DC_GREY;
-
-// this figure is from the IEA's 2018 report for a global average:
-const CO2_PER_KWH_NETWORK_GREY = 475;
-
-// The IEA figures cover electricity but as far as I can tell, it does not
-// cover life cycle emissions, and the 1byte models appears to do the same
-// so, we use zero emissions for green infra in the DC
-// https://github.com/thegreenwebfoundation/co2.js/issues/2
-const CO2_PER_KWH_IN_DC_GREEN = 0;
+const onebyte = require("./1byte.js");
 
 class CO2 {
   constructor(options) {
     this.options = options;
+
+    // default model
+    this.model = new onebyte.OneByte()
+
+    if (options) {
+      this.model = new options.model();
+    }
+
   }
 
+  // return a CO2 figure for energy used to shift the corresponding
+  // the data transfer.
   perByte(bytes, green) {
-    // return a CO2 figure for energy used to shift the corresponding
-    // the data transfer.
-
-    if (bytes < 1) {
-      return 0;
-    }
-
-    if (green) {
-      // if we have a green datacentre, use the lower figure for renewable energy
-      const Co2ForDC = bytes * KWH_PER_BYTE_IN_DC * CO2_PER_KWH_IN_DC_GREEN;
-
-      // but for the rest of the internet, we can't easily check, so assume
-      // grey for now
-      const Co2forNetwork =
-        bytes * KWH_PER_BYTE_FOR_NETWORK * CO2_PER_KWH_NETWORK_GREY;
-
-      return Co2ForDC + Co2forNetwork;
-    }
-
-    const KwHPerByte = KWH_PER_BYTE_IN_DC + KWH_PER_BYTE_FOR_NETWORK;
-    return bytes * KwHPerByte * CO2_PER_KWH_IN_DC_GREY;
+    return this.model.perByte(bytes, green)
   }
 
   perDomain(pageXray, greenDomains) {

--- a/src/co2.js
+++ b/src/co2.js
@@ -15,8 +15,17 @@ class CO2 {
     }
   }
 
-  // return a CO2 figure for energy used to shift the corresponding
-  // the data transfer.
+  //
+  //
+  /**
+   * Accept a figure in bytes for data transfer, and a boolean for whether
+   * the domain shows as 'green', and return a CO2 figure for energy used to shift the corresponding
+   * the data transfer.
+   *
+   * @param {number} bytes
+   * @param {boolean} green
+   * @return {number} the amount of CO2 in grammes
+   */
   perByte(bytes, green) {
     return this.model.perByte(bytes, green);
   }

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -11,7 +11,6 @@ describe("co2", () => {
   let har, co2;
 
   describe("1 byte model", () => {
-
     const TGWF_GREY_VALUE = 0.20497;
     const TGWF_GREEN_VALUE = 0.54704;
     const TGWF_MIXED_VALUE = 0.16718;
@@ -19,7 +18,6 @@ describe("co2", () => {
     const MILLION = 1000000;
     const MILLION_GREY = 0.29081;
     const MILLION_GREEN = 0.23196;
-
 
     beforeEach(() => {
       co2 = new CO2();
@@ -149,18 +147,16 @@ describe("co2", () => {
   });
 
   describe("Sustainable Web Design model", () => {
-
     // the SWD model should have slightly higher values as
     // we include more of the system in calculations for the
     // same levels of data transfer
     const MILLION = 1000000;
     const MILLION_GREY = 0.33343;
-    const MILLION_GREEN = 0.28908
+    const MILLION_GREEN = 0.28908;
 
     const TGWF_GREY_VALUE = 0.23501;
     const TGWF_GREEN_VALUE = 0.54704;
-    const TGWF_MIXED_VALUE = 0.20652
-
+    const TGWF_MIXED_VALUE = 0.20652;
 
     beforeEach(() => {
       co2 = new CO2({ model: swd });
@@ -174,7 +170,7 @@ describe("co2", () => {
 
     describe("perByte", () => {
       it("returns a CO2 number for data transfer", () => {
-        co2.perByte(MILLION)
+        co2.perByte(MILLION);
         expect(co2.perByte(MILLION).toPrecision(5)).toBe(
           MILLION_GREY.toPrecision(5)
         );

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const path = require("path");
 
 const CO2 = require("./co2");
-const swd = require("./sustainable-web-design")
+const swd = require("./sustainable-web-design");
 const pagexray = require("pagexray");
 
 describe("co2", () => {
@@ -18,7 +18,6 @@ describe("co2", () => {
   const MILLION_GREEN = 0.23196;
 
   describe("1 byte model", () => {
-
     beforeEach(() => {
       co2 = new CO2();
       har = JSON.parse(
@@ -28,7 +27,6 @@ describe("co2", () => {
         )
       );
     });
-
 
     describe("perByte", () => {
       it("returns a CO2 number for data transfer using 'grey' power", () => {
@@ -145,10 +143,9 @@ describe("co2", () => {
         }
       });
     });
-  })
+  });
 
   describe("Sustainable Web Design model", () => {
-
     beforeEach(() => {
       co2 = new CO2({ model: swd });
       har = JSON.parse(
@@ -157,7 +154,7 @@ describe("co2", () => {
           "utf8"
         )
       );
-    })
+    });
     // for the two models we need to decide how much we leave to the model
     // and how much we leave to CO2 js
     describe("perByte", () => {
@@ -165,9 +162,6 @@ describe("co2", () => {
         // TODO add tesr to check for the existence of a simplest
         // version of the API we support
       });
-
     });
-
-
-  })
+  });
 });

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -39,7 +39,7 @@ describe("co2", () => {
       });
 
       it("returns a lower CO2 number for data transfer from domains using entirely 'green' power", () => {
-        expect(co2.perByte(MILLION, false).toPrecision(5)).toBe(
+        expect(co2.perByte(MILLION).toPrecision(5)).toBe(
           MILLION_GREY.toPrecision(5)
         );
         expect(co2.perByte(MILLION, true).toPrecision(5)).toBe(
@@ -155,11 +155,11 @@ describe("co2", () => {
     // same levels of data transfer
     const MILLION = 1000000;
     const MILLION_GREY = 0.33343;
-    const MILLION_GREEN = 0.28342
+    const MILLION_GREEN = 0.28908
 
     const TGWF_GREY_VALUE = 0.23501;
     const TGWF_GREEN_VALUE = 0.54704;
-    const TGWF_MIXED_VALUE = 0.20296;
+    const TGWF_MIXED_VALUE = 0.20652
 
 
     beforeEach(() => {
@@ -184,6 +184,7 @@ describe("co2", () => {
         expect(co2.perByte(MILLION, false).toPrecision(5)).toBe(
           MILLION_GREY.toPrecision(5)
         );
+
         expect(co2.perByte(MILLION, true).toPrecision(5)).toBe(
           MILLION_GREEN.toPrecision(5)
         );

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -9,15 +9,18 @@ const pagexray = require("pagexray");
 
 describe("co2", () => {
   let har, co2;
-  const TGWF_GREY_VALUE = 0.20497;
-  const TGWF_GREEN_VALUE = 0.54704;
-  const TGWF_MIXED_VALUE = 0.16718;
-
-  const MILLION = 1000000;
-  const MILLION_GREY = 0.29081;
-  const MILLION_GREEN = 0.23196;
 
   describe("1 byte model", () => {
+
+    const TGWF_GREY_VALUE = 0.20497;
+    const TGWF_GREEN_VALUE = 0.54704;
+    const TGWF_MIXED_VALUE = 0.16718;
+
+    const MILLION = 1000000;
+    const MILLION_GREY = 0.29081;
+    const MILLION_GREEN = 0.23196;
+
+
     beforeEach(() => {
       co2 = new CO2();
       har = JSON.parse(
@@ -146,6 +149,19 @@ describe("co2", () => {
   });
 
   describe("Sustainable Web Design model", () => {
+
+    // the SWD model should have slightly higher values as
+    // we include more of the system in calculations for the
+    // same levels of data transfer
+    const MILLION = 1000000;
+    const MILLION_GREY = 0.33343;
+    const MILLION_GREEN = 0.28342
+
+    const TGWF_GREY_VALUE = 0.23501;
+    const TGWF_GREEN_VALUE = 0.54704;
+    const TGWF_MIXED_VALUE = 0.20296;
+
+
     beforeEach(() => {
       co2 = new CO2({ model: swd });
       har = JSON.parse(
@@ -155,12 +171,121 @@ describe("co2", () => {
         )
       );
     });
-    // for the two models we need to decide how much we leave to the model
-    // and how much we leave to CO2 js
+
     describe("perByte", () => {
-      it.skip("returns a CO2 number for data transfer", () => {
-        // TODO add tesr to check for the existence of a simplest
-        // version of the API we support
+      it("returns a CO2 number for data transfer", () => {
+        co2.perByte(MILLION)
+        expect(co2.perByte(MILLION).toPrecision(5)).toBe(
+          MILLION_GREY.toPrecision(5)
+        );
+      });
+
+      it("returns a lower CO2 number for data transfer from domains using entirely 'green' power", () => {
+        expect(co2.perByte(MILLION, false).toPrecision(5)).toBe(
+          MILLION_GREY.toPrecision(5)
+        );
+        expect(co2.perByte(MILLION, true).toPrecision(5)).toBe(
+          MILLION_GREEN.toPrecision(5)
+        );
+      });
+    });
+
+    describe("perPage", () => {
+      it("returns CO2 for total transfer for page", () => {
+        const pages = pagexray.convert(har);
+        const pageXrayRun = pages[0];
+
+        expect(co2.perPage(pageXrayRun).toPrecision(5)).toBe(
+          TGWF_GREY_VALUE.toPrecision(5)
+        );
+      });
+      it("returns lower CO2 for page served from green site", () => {
+        const pages = pagexray.convert(har);
+        const pageXrayRun = pages[0];
+        let green = [
+          "www.thegreenwebfoundation.org",
+          "fonts.googleapis.com",
+          "ajax.googleapis.com",
+          "assets.digitalclimatestrike.net",
+          "cdnjs.cloudflare.com",
+          "graphite.thegreenwebfoundation.org",
+          "analytics.thegreenwebfoundation.org",
+          "fonts.gstatic.com",
+          "api.thegreenwebfoundation.org",
+        ];
+        expect(co2.perPage(pageXrayRun, green)).toBeLessThan(TGWF_GREY_VALUE);
+      });
+      it("returns a lower CO2 number where *some* domains use green power", () => {
+        const pages = pagexray.convert(har);
+        const pageXrayRun = pages[0];
+        // green can be true, or a array containing entries
+        let green = [
+          "www.thegreenwebfoundation.org",
+          "fonts.googleapis.com",
+          "ajax.googleapis.com",
+          "assets.digitalclimatestrike.net",
+          "cdnjs.cloudflare.com",
+          "graphite.thegreenwebfoundation.org",
+          "analytics.thegreenwebfoundation.org",
+          "fonts.gstatic.com",
+          "api.thegreenwebfoundation.org",
+        ];
+        expect(co2.perPage(pageXrayRun, green).toPrecision(5)).toBe(
+          TGWF_MIXED_VALUE.toPrecision(5)
+        );
+      });
+    });
+    describe("perDomain", () => {
+      it("shows object listing Co2 for each domain", () => {
+        const pages = pagexray.convert(har);
+        const pageXrayRun = pages[0];
+        const res = co2.perDomain(pageXrayRun);
+
+        const domains = [
+          "thegreenwebfoundation.org",
+          "www.thegreenwebfoundation.org",
+          "maxcdn.bootstrapcdn.com",
+          "fonts.googleapis.com",
+          "ajax.googleapis.com",
+          "assets.digitalclimatestrike.net",
+          "cdnjs.cloudflare.com",
+          "graphite.thegreenwebfoundation.org",
+          "analytics.thegreenwebfoundation.org",
+          "fonts.gstatic.com",
+          "api.thegreenwebfoundation.org",
+        ];
+
+        for (let obj of res) {
+          expect(domains.indexOf(obj.domain)).toBeGreaterThan(-1);
+          expect(typeof obj.co2).toBe("number");
+        }
+      });
+      it("shows lower Co2 for green domains", () => {
+        const pages = pagexray.convert(har);
+        const pageXrayRun = pages[0];
+
+        const greenDomains = [
+          "www.thegreenwebfoundation.org",
+          "fonts.googleapis.com",
+          "ajax.googleapis.com",
+          "assets.digitalclimatestrike.net",
+          "cdnjs.cloudflare.com",
+          "graphite.thegreenwebfoundation.org",
+          "analytics.thegreenwebfoundation.org",
+          "fonts.gstatic.com",
+          "api.thegreenwebfoundation.org",
+        ];
+        const res = co2.perDomain(pageXrayRun);
+        const resWithGreen = co2.perDomain(pageXrayRun, greenDomains);
+
+        for (let obj of res) {
+          expect(typeof obj.co2).toBe("number");
+        }
+        for (let obj of greenDomains) {
+          let index = 0;
+          expect(resWithGreen[index].co2).toBeLessThan(res[index].co2);
+          index++;
+        }
       });
     });
   });

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -4,9 +4,10 @@ const fs = require("fs");
 const path = require("path");
 
 const CO2 = require("./co2");
+const swd = require("./sustainable-web-design")
 const pagexray = require("pagexray");
 
-describe("co2", function () {
+describe("co2", () => {
   let har, co2;
   const TGWF_GREY_VALUE = 0.20497;
   const TGWF_GREEN_VALUE = 0.54704;
@@ -16,135 +17,157 @@ describe("co2", function () {
   const MILLION_GREY = 0.29081;
   const MILLION_GREEN = 0.23196;
 
-  beforeEach(function () {
-    co2 = new CO2();
-    har = JSON.parse(
-      fs.readFileSync(
-        path.resolve(__dirname, "../data/fixtures/tgwf.har"),
-        "utf8"
-      )
-    );
-  });
+  describe("1 byte model", () => {
 
-  describe("perByte", function () {
-    it("returns a CO2 number for data transfer using 'grey' power", function () {
-      expect(co2.perByte(MILLION).toPrecision(5)).toBe(
-        MILLION_GREY.toPrecision(5)
+    beforeEach(() => {
+      co2 = new CO2();
+      har = JSON.parse(
+        fs.readFileSync(
+          path.resolve(__dirname, "../data/fixtures/tgwf.har"),
+          "utf8"
+        )
       );
     });
 
-    it("returns a lower CO2 number for data transfer from domains using entirely 'green' power", function () {
-      expect(co2.perByte(MILLION, false).toPrecision(5)).toBe(
-        MILLION_GREY.toPrecision(5)
+
+    describe("perByte", () => {
+      it("returns a CO2 number for data transfer using 'grey' power", () => {
+        expect(co2.perByte(MILLION).toPrecision(5)).toBe(
+          MILLION_GREY.toPrecision(5)
+        );
+      });
+
+      it("returns a lower CO2 number for data transfer from domains using entirely 'green' power", () => {
+        expect(co2.perByte(MILLION, false).toPrecision(5)).toBe(
+          MILLION_GREY.toPrecision(5)
+        );
+        expect(co2.perByte(MILLION, true).toPrecision(5)).toBe(
+          MILLION_GREEN.toPrecision(5)
+        );
+      });
+    });
+
+    describe("perPage", () => {
+      it("returns CO2 for total transfer for page", () => {
+        const pages = pagexray.convert(har);
+        const pageXrayRun = pages[0];
+
+        expect(co2.perPage(pageXrayRun).toPrecision(5)).toBe(
+          TGWF_GREY_VALUE.toPrecision(5)
+        );
+      });
+      it("returns lower CO2 for page served from green site", () => {
+        const pages = pagexray.convert(har);
+        const pageXrayRun = pages[0];
+        let green = [
+          "www.thegreenwebfoundation.org",
+          "fonts.googleapis.com",
+          "ajax.googleapis.com",
+          "assets.digitalclimatestrike.net",
+          "cdnjs.cloudflare.com",
+          "graphite.thegreenwebfoundation.org",
+          "analytics.thegreenwebfoundation.org",
+          "fonts.gstatic.com",
+          "api.thegreenwebfoundation.org",
+        ];
+        expect(co2.perPage(pageXrayRun, green)).toBeLessThan(TGWF_GREY_VALUE);
+      });
+      it("returns a lower CO2 number where *some* domains use green power", () => {
+        const pages = pagexray.convert(har);
+        const pageXrayRun = pages[0];
+        // green can be true, or a array containing entries
+        let green = [
+          "www.thegreenwebfoundation.org",
+          "fonts.googleapis.com",
+          "ajax.googleapis.com",
+          "assets.digitalclimatestrike.net",
+          "cdnjs.cloudflare.com",
+          "graphite.thegreenwebfoundation.org",
+          "analytics.thegreenwebfoundation.org",
+          "fonts.gstatic.com",
+          "api.thegreenwebfoundation.org",
+        ];
+        expect(co2.perPage(pageXrayRun, green).toPrecision(5)).toBe(
+          TGWF_MIXED_VALUE.toPrecision(5)
+        );
+      });
+    });
+    describe("perDomain", () => {
+      it("shows object listing Co2 for each domain", () => {
+        const pages = pagexray.convert(har);
+        const pageXrayRun = pages[0];
+        const res = co2.perDomain(pageXrayRun);
+
+        const domains = [
+          "thegreenwebfoundation.org",
+          "www.thegreenwebfoundation.org",
+          "maxcdn.bootstrapcdn.com",
+          "fonts.googleapis.com",
+          "ajax.googleapis.com",
+          "assets.digitalclimatestrike.net",
+          "cdnjs.cloudflare.com",
+          "graphite.thegreenwebfoundation.org",
+          "analytics.thegreenwebfoundation.org",
+          "fonts.gstatic.com",
+          "api.thegreenwebfoundation.org",
+        ];
+
+        for (let obj of res) {
+          expect(domains.indexOf(obj.domain)).toBeGreaterThan(-1);
+          expect(typeof obj.co2).toBe("number");
+        }
+      });
+      it("shows lower Co2 for green domains", () => {
+        const pages = pagexray.convert(har);
+        const pageXrayRun = pages[0];
+
+        const greenDomains = [
+          "www.thegreenwebfoundation.org",
+          "fonts.googleapis.com",
+          "ajax.googleapis.com",
+          "assets.digitalclimatestrike.net",
+          "cdnjs.cloudflare.com",
+          "graphite.thegreenwebfoundation.org",
+          "analytics.thegreenwebfoundation.org",
+          "fonts.gstatic.com",
+          "api.thegreenwebfoundation.org",
+        ];
+        const res = co2.perDomain(pageXrayRun);
+        const resWithGreen = co2.perDomain(pageXrayRun, greenDomains);
+
+        for (let obj of res) {
+          expect(typeof obj.co2).toBe("number");
+        }
+        for (let obj of greenDomains) {
+          let index = 0;
+          expect(resWithGreen[index].co2).toBeLessThan(res[index].co2);
+          index++;
+        }
+      });
+    });
+  })
+
+  describe("Sustainable Web Design model", () => {
+
+    beforeEach(() => {
+      co2 = new CO2({ model: swd });
+      har = JSON.parse(
+        fs.readFileSync(
+          path.resolve(__dirname, "../data/fixtures/tgwf.har"),
+          "utf8"
+        )
       );
-      expect(co2.perByte(MILLION, true).toPrecision(5)).toBe(
-        MILLION_GREEN.toPrecision(5)
-      );
-    });
-  });
+    })
+    // for the two models we need to decide how much we leave to the model
+    // and how much we leave to CO2 js
+    describe("perByte", () => {
+      it.skip("returns a CO2 number for data transfer", () => {
+        // TODO add tesr to check for the existence of a simplest
+        // version of the API we support
+      });
 
-  describe("perPage", function () {
-    it("returns CO2 for total transfer for page", function () {
-      const pages = pagexray.convert(har);
-      const pageXrayRun = pages[0];
-
-      expect(co2.perPage(pageXrayRun).toPrecision(5)).toBe(
-        TGWF_GREY_VALUE.toPrecision(5)
-      );
     });
-    it("returns lower CO2 for page served from green site", function () {
-      const pages = pagexray.convert(har);
-      const pageXrayRun = pages[0];
-      let green = [
-        "www.thegreenwebfoundation.org",
-        "fonts.googleapis.com",
-        "ajax.googleapis.com",
-        "assets.digitalclimatestrike.net",
-        "cdnjs.cloudflare.com",
-        "graphite.thegreenwebfoundation.org",
-        "analytics.thegreenwebfoundation.org",
-        "fonts.gstatic.com",
-        "api.thegreenwebfoundation.org",
-      ];
-      expect(co2.perPage(pageXrayRun, green)).toBeLessThan(TGWF_GREY_VALUE);
-    });
-    it("returns a lower CO2 number where *some* domains use green power", function () {
-      const pages = pagexray.convert(har);
-      const pageXrayRun = pages[0];
-      // green can be true, or a array containing entries
-      let green = [
-        "www.thegreenwebfoundation.org",
-        "fonts.googleapis.com",
-        "ajax.googleapis.com",
-        "assets.digitalclimatestrike.net",
-        "cdnjs.cloudflare.com",
-        "graphite.thegreenwebfoundation.org",
-        "analytics.thegreenwebfoundation.org",
-        "fonts.gstatic.com",
-        "api.thegreenwebfoundation.org",
-      ];
-      expect(co2.perPage(pageXrayRun, green).toPrecision(5)).toBe(
-        TGWF_MIXED_VALUE.toPrecision(5)
-      );
-    });
-  });
-  describe("perDomain", function () {
-    it("shows object listing Co2 for each domain", function () {
-      const pages = pagexray.convert(har);
-      const pageXrayRun = pages[0];
-      const res = co2.perDomain(pageXrayRun);
 
-      const domains = [
-        "thegreenwebfoundation.org",
-        "www.thegreenwebfoundation.org",
-        "maxcdn.bootstrapcdn.com",
-        "fonts.googleapis.com",
-        "ajax.googleapis.com",
-        "assets.digitalclimatestrike.net",
-        "cdnjs.cloudflare.com",
-        "graphite.thegreenwebfoundation.org",
-        "analytics.thegreenwebfoundation.org",
-        "fonts.gstatic.com",
-        "api.thegreenwebfoundation.org",
-      ];
 
-      for (let obj of res) {
-        expect(domains.indexOf(obj.domain)).toBeGreaterThan(-1);
-        expect(typeof obj.co2).toBe("number");
-      }
-    });
-    it("shows lower Co2 for green domains", function () {
-      const pages = pagexray.convert(har);
-      const pageXrayRun = pages[0];
-
-      const greenDomains = [
-        "www.thegreenwebfoundation.org",
-        "fonts.googleapis.com",
-        "ajax.googleapis.com",
-        "assets.digitalclimatestrike.net",
-        "cdnjs.cloudflare.com",
-        "graphite.thegreenwebfoundation.org",
-        "analytics.thegreenwebfoundation.org",
-        "fonts.gstatic.com",
-        "api.thegreenwebfoundation.org",
-      ];
-      const res = co2.perDomain(pageXrayRun);
-      const resWithGreen = co2.perDomain(pageXrayRun, greenDomains);
-
-      for (let obj of res) {
-        expect(typeof obj.co2).toBe("number");
-      }
-      for (let obj of greenDomains) {
-        let index = 0;
-        expect(resWithGreen[index].co2).toBeLessThan(res[index].co2);
-        index++;
-      }
-    });
-  });
-  // describe('perContentType', function () {
-  //   test.skip('shows a breakdown of emissions by content type');
-  // });
-  // describe('dirtiestResources', function () {
-  //   it.skip('shows the top 10 resources by CO2 emissions');
-  // });
+  })
 });

--- a/src/hosting-api.test.js
+++ b/src/hosting-api.test.js
@@ -3,9 +3,9 @@
 const hosting = require("./hosting-api");
 const nock = require("nock");
 
-describe("hostingAPI", function () {
-  describe("checking a single domain with #check", function () {
-    it("using the API", async function () {
+describe("hostingAPI", () => {
+  describe("checking a single domain with #check", () => {
+    it("using the API", async () => {
       const scope = nock("https://api.thegreenwebfoundation.org/")
         .get("/greencheck/google.com")
         .reply(200, {
@@ -16,8 +16,8 @@ describe("hostingAPI", function () {
       expect(res).toEqual(true);
     });
   });
-  describe("implicitly checking multiple domains with #check", function () {
-    it("using the API", async function () {
+  describe("implicitly checking multiple domains with #check", () => {
+    it("using the API", async () => {
       const scope = nock("https://api.thegreenwebfoundation.org/")
         .get("/v2/greencheckmulti/[%22google.com%22,%22kochindustries.com%22]")
         .reply(200, {

--- a/src/hosting-database.test.js
+++ b/src/hosting-database.test.js
@@ -12,15 +12,15 @@ const dbPath = path.resolve(
   "url2green.test.db"
 );
 
-describe("hostingDatabase", function () {
-  describe("checking a single domain with #check", function () {
-    test("tries to use a local database if available ", async function () {
+describe("hostingDatabase", () => {
+  describe("checking a single domain with #check", () => {
+    test("tries to use a local database if available ", async () => {
       const res = await hosting.check("google.com", dbPath);
       expect(res).toEqual(true);
     });
   });
-  describe("implicitly checking multiple domains with #check", function () {
-    test("tries to use a local database if available", async function () {
+  describe("implicitly checking multiple domains with #check", () => {
+    test("tries to use a local database if available", async () => {
       const res = await hosting.check(
         ["google.com", "kochindustries.com"],
         dbPath

--- a/src/hosting-json.test.js
+++ b/src/hosting-json.test.js
@@ -3,7 +3,7 @@
 const hosting = require("./hosting-json");
 const path = require("path");
 
-describe("hostingJSON", function () {
+describe("hostingJSON", () => {
   const jsonPath = path.resolve(
     __dirname,
     "..",
@@ -18,22 +18,22 @@ describe("hostingJSON", function () {
     "fixtures",
     "url2green.test.json.gz"
   );
-  describe("checking a single domain with #check", function () {
-    test("against the list of domains as JSON", async function () {
+  describe("checking a single domain with #check", () => {
+    test("against the list of domains as JSON", async () => {
       const db = await hosting.loadJSON(jsonPath);
       const res = await hosting.check("google.com", db);
       expect(res).toEqual(true);
     });
   });
-  describe("checking a single domain with #check", function () {
-    test("against the list of domains as JSON loaded from a gzipped JSON", async function () {
+  describe("checking a single domain with #check", () => {
+    test("against the list of domains as JSON loaded from a gzipped JSON", async () => {
       const db = await hosting.loadJSON(jsonPathGz);
       const res = await hosting.check("google.com", db);
       expect(res).toEqual(true);
     });
   });
-  describe("implicitly checking multiple domains with #check", function () {
-    test("against the list of domains as JSON", async function () {
+  describe("implicitly checking multiple domains with #check", () => {
+    test("against the list of domains as JSON", async () => {
       const db = await hosting.loadJSON(jsonPath);
       const domains = ["google.com", "kochindustries.com"];
 

--- a/src/hosting.test.js
+++ b/src/hosting.test.js
@@ -14,9 +14,9 @@ const jsonPath = path.resolve(
   "url2green.test.json"
 );
 
-describe("hosting", function () {
+describe("hosting", () => {
   let har;
-  beforeEach(function () {
+  beforeEach(() => {
     har = JSON.parse(
       fs.readFileSync(
         path.resolve(__dirname, "../data/fixtures/tgwf.har"),
@@ -24,8 +24,8 @@ describe("hosting", function () {
       )
     );
   });
-  describe("checking all domains on a page object with #checkPage ", function () {
-    it("it returns a list of green domains, when passed a page object", async function () {
+  describe("checking all domains on a page object with #checkPage ", () => {
+    it("it returns a list of green domains, when passed a page object", async () => {
       const pages = pagexray.convert(har);
       const pageXrayRun = pages[0];
       const db = await hosting.loadJSON(jsonPath);
@@ -53,23 +53,23 @@ describe("hosting", function () {
     //   'it returns an empty list, when passed a page object with no green domains'
     // );
   });
-  describe("checking a single domain with #check", function () {
-    it("use the API instead", async function () {
+  describe("checking a single domain with #check", () => {
+    it("use the API instead", async () => {
       const db = await hosting.loadJSON(jsonPath);
       const res = await hosting.check("google.com", db);
       expect(res).toEqual(true);
     });
   });
-  describe("implicitly checking multiple domains with #check", function () {
-    it("Use the API", async function () {
+  describe("implicitly checking multiple domains with #check", () => {
+    it("Use the API", async () => {
       const db = await hosting.loadJSON(jsonPath);
 
       const res = await hosting.check(["google.com", "kochindustries.com"], db);
       expect(res).toContain("google.com");
     });
   });
-  describe("explicitly checking multiple domains with #checkMulti", function () {
-    it("use the API", async function () {
+  describe("explicitly checking multiple domains with #checkMulti", () => {
+    it("use the API", async () => {
       const db = await hosting.loadJSON(jsonPath);
       const res = await hosting.check(["google.com", "kochindustries.com"], db);
       expect(res).toContain("google.com");

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -67,20 +67,20 @@ class SustainableWebDesign {
    * @return {number} the total number in grams of CO2 equivalent emissions
    */
   co2byComponent(energyBycomponent, carbonIntensity = GLOBAL_INTENSITY) {
-    const co2byComponent = {};
+    const returnCO2ByComponent = {};
     for (const [key, value] of Object.entries(energyBycomponent)) {
       // we update the datacentre, as that's what we have information
       // about.
       if (key === "dataCenterEnergy") {
-        co2byComponent[key] = value * carbonIntensity;
+        returnCO2ByComponent[key] = value * carbonIntensity;
       } else {
         // We don't have info about the device location,
         // nor the network path used, nor the production emissions
         // so we revert to global figures
-        co2byComponent[key] = value * GLOBAL_INTENSITY;
+        returnCO2ByComponent[key] = value * GLOBAL_INTENSITY;
       }
     }
-    return co2byComponent;
+    return returnCO2ByComponent;
   }
 
   /**
@@ -113,22 +113,10 @@ class SustainableWebDesign {
       );
     }
 
-    const co2byComponent = {};
-    for (const [key, value] of Object.entries(energyBycomponent)) {
-      // we update the datacentre, as that's what we have information
-      // about.
-      if (key === "dataCenterEnergy") {
-        co2byComponent[key] = value * carbonIntensity;
-      } else {
-        // We don't have info about the device location,
-        // nor the network path used, nor the production emissions
-        // so we revert to global figures
-        co2byComponent[key] = value * GLOBAL_INTENSITY;
-      }
-    }
+    const co2ValuesbyComponent = this.co2byComponent(energyBycomponent, carbonIntensity)
 
     // pull out our values…
-    const co2Values = Object.values(co2byComponent);
+    const co2Values = Object.values(co2ValuesbyComponent);
 
     // so we can return their sum
     return co2Values.reduce(

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -190,6 +190,8 @@ class SustainableWebDesign {
     );
   }
 
+  // TODO: this method looks like it applies the carbon intensity
+  // change to the *entire* system, not just the datacenter.
   emissionsPerVisitInGrams(energyPerVisit, carbonintensity = GLOBAL_INTENSITY) {
     return formatNumber(energyPerVisit * carbonintensity);
   }

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -16,17 +16,48 @@ const KWH_PER_GB = 0.81;
 // Taken from: https://ember-climate.org/data/data-explorer
 // - Global carbon intensity for 2021
 
+
+
 const GLOBAL_INTENSITY = 442;
+// TODO add proper weighted average for non co2 emitting sources,
+// like wind, solar, hydro
+const RENEWABLES_INTENSITY = 0
+
+
 // Taken from: https://gitlab.com/wholegrain/carbon-api-2-0/-/blob/master/includes/carbonapi.php
 const FIRST_TIME_VIEWING_PERCENTAGE = 0.25;
 const RETURNING_VISITOR_PERCENTAGE = 0.75;
 const PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD = 0.02;
 // Taken from: https://sustainablewebdesign.org/calculating-digital-emissions/#:~:text=Consumer%20device%20energy%20%3D%20AE%20x%200.52
+
 const END_USER_DEVICE_ENERGY = 0.52;
+const NETWORK_ENERGY = 0.14;
+const DATACENTER_ENERGY = 0.15
+const PRODUCTION_ENERGY = 0.19
+
 
 class SustainableWebDesign {
   constructor(options) {
     this.options = options;
+  }
+
+
+  /**
+   * Accept a figure for bytes transferred and return a figure for CO2
+   * emissions. If transfer is for a domain served by renewables, return
+   * a figure to account for this
+   *
+   * @param {Number} bytes
+   * @param {boolean} green
+   * @return {Number}
+   */
+  perByte(bytes, green) {
+    const transferedBytesToGb = bytes / fileSize.GIGABYTE;
+    const energyUsage = transferedBytesToGb * KWH_PER_GB
+    return energyUsage * GLOBAL_INTENSITY
+
+
+
   }
 
   energyPerVisit(bytes) {
@@ -58,9 +89,9 @@ class SustainableWebDesign {
   annualSegmentEnergy(annualEnergy) {
     return {
       consumerDeviceEnergy: formatNumber(annualEnergy * END_USER_DEVICE_ENERGY),
-      networkEnergy: formatNumber(annualEnergy * 0.14),
-      dataCenterEnergy: formatNumber(annualEnergy * 0.15),
-      productionEnergy: formatNumber(annualEnergy * 0.19),
+      networkEnergy: formatNumber(annualEnergy * NETWORK_ENERGY),
+      dataCenterEnergy: formatNumber(annualEnergy * DATACENTER_ENERGY),
+      productionEnergy: formatNumber(annualEnergy * PRODUCTION_ENERGY),
     };
   }
 }

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -148,9 +148,16 @@ class SustainableWebDesign {
 
   /**
    * Accept a figure for bytes transferred, and return an object containing figures
-   * per system component, with the caching assumptions applied
+   * per system component, with the caching assumptions applied. This tries to account
+   * for webpages being loaded from a cache by browsers, so if you had a thousand page views,
+   * and tried to work out the energy per visit, the numbers would reflect the reduced amounts
+   * of transfer.
    *
-   * @param {number} bytes - the data transferred in bytes
+   * @param {number} bytes - the data transferred in bytes for loading a webpage
+   * @param {number} firstView - what percentage of visits are loading this page for the first time
+   * @param {number} returnView - what percentage of visits are loading this page for subsequent times
+   * @param {number} dataReloadRatio - what percentage of a page is reloaded on each subsequent page view
+   *
    * @return {object} Object containing the energy in kilowatt hours, keyed by system component
    */
   energyPerVisitByComponent(

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -33,9 +33,6 @@ const FIRST_TIME_VIEWING_PERCENTAGE = 0.25;
 const RETURNING_VISITOR_PERCENTAGE = 0.75;
 const PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD = 0.02;
 
-
-
-
 class SustainableWebDesign {
   constructor(options) {
     this.options = options;
@@ -50,7 +47,6 @@ class SustainableWebDesign {
    * @return {object} Object containing the energy in kilowatt hours, keyed by system component
    */
   energyPerByteByComponent(bytes) {
-
     const transferedBytesToGb = bytes / fileSize.GIGABYTE;
     const energyUsage = transferedBytesToGb * KWH_PER_GB;
 
@@ -60,7 +56,7 @@ class SustainableWebDesign {
       networkEnergy: energyUsage * NETWORK_ENERGY,
       productionEnergy: energyUsage * PRODUCTION_ENERGY,
       dataCenterEnergy: energyUsage * DATACENTER_ENERGY,
-    }
+    };
   }
   /**
    * Accept an object keys by the different system components, and
@@ -71,20 +67,20 @@ class SustainableWebDesign {
    * @return {number} the total number in grams of CO2 equivalent emissions
    */
   co2byComponent(energyBycomponent, carbonIntensity = GLOBAL_INTENSITY) {
-    const co2byComponent = {}
+    const co2byComponent = {};
     for (const [key, value] of Object.entries(energyBycomponent)) {
       // we update the datacentre, as that's what we have information
       // about.
-      if (key === 'dataCenterEnergy') {
-        co2byComponent[key] = value * carbonIntensity
+      if (key === "dataCenterEnergy") {
+        co2byComponent[key] = value * carbonIntensity;
       } else {
         // We don't have info about the device location,
         // nor the network path used, nor the production emissions
         // so we revert to global figures
-        co2byComponent[key] = value * GLOBAL_INTENSITY
+        co2byComponent[key] = value * GLOBAL_INTENSITY;
       }
     }
-    return co2byComponent
+    return co2byComponent;
   }
 
   /**
@@ -98,46 +94,47 @@ class SustainableWebDesign {
    * @return {number} the total number in grams of CO2 equivalent emissions
    */
   perByte(bytes, carbonIntensity = GLOBAL_INTENSITY) {
-    const energyBycomponent = this.energyPerByteByComponent(bytes)
+    const energyBycomponent = this.energyPerByteByComponent(bytes);
 
     // when faced with falsy values, fallback to global intensity
     if (Boolean(carbonIntensity) === false) {
-      carbonIntensity = GLOBAL_INTENSITY
+      carbonIntensity = GLOBAL_INTENSITY;
     }
     // if we have a boolean, we have a green result from the green web checker
     // use the renewables intensity
     if (carbonIntensity === true) {
-      carbonIntensity = RENEWABLES_INTENSITY
+      carbonIntensity = RENEWABLES_INTENSITY;
     }
 
     // otherwise when faced with non numeric values throw an error
-    if (typeof carbonIntensity !== 'number') {
+    if (typeof carbonIntensity !== "number") {
       throw new Error(
         `perByte expects a numeric value or boolean for the carbon intensity value. Received: ${carbonIntensity}`
       );
     }
 
-    const co2byComponent = {}
+    const co2byComponent = {};
     for (const [key, value] of Object.entries(energyBycomponent)) {
       // we update the datacentre, as that's what we have information
       // about.
-      if (key === 'dataCenterEnergy') {
-        co2byComponent[key] = value * carbonIntensity
+      if (key === "dataCenterEnergy") {
+        co2byComponent[key] = value * carbonIntensity;
       } else {
         // We don't have info about the device location,
         // nor the network path used, nor the production emissions
         // so we revert to global figures
-        co2byComponent[key] = value * GLOBAL_INTENSITY
+        co2byComponent[key] = value * GLOBAL_INTENSITY;
       }
     }
 
     // pull out our values…
-    const co2Values = Object.values(co2byComponent)
+    const co2Values = Object.values(co2byComponent);
 
     // so we can return their sum
-    return co2Values.reduce((prevValue, currentValue) => prevValue + currentValue)
+    return co2Values.reduce(
+      (prevValue, currentValue) => prevValue + currentValue
+    );
   }
-
 
   /**
    * Accept a figure for bytes transferred and return the number of kilowatt hours used
@@ -147,13 +144,15 @@ class SustainableWebDesign {
    * @return {number} the number of kilowatt hours used
    */
   energyPerByte(bytes) {
-    const energyByComponent = this.energyPerByteByComponent(bytes)
+    const energyByComponent = this.energyPerByteByComponent(bytes);
 
     // pull out our values…
-    const energyValues = Object.values(energyByComponent)
+    const energyValues = Object.values(energyByComponent);
 
     // so we can return their sum
-    return energyValues.reduce((prevValue, currentValue) => prevValue + currentValue)
+    return energyValues.reduce(
+      (prevValue, currentValue) => prevValue + currentValue
+    );
   }
 
   /**
@@ -163,23 +162,24 @@ class SustainableWebDesign {
    * @param {number} bytes - the data transferred in bytes
    * @return {object} Object containing the energy in kilowatt hours, keyed by system component
    */
-  energyPerVisitByComponent(bytes,
+  energyPerVisitByComponent(
+    bytes,
     firstView = FIRST_TIME_VIEWING_PERCENTAGE,
     returnView = RETURNING_VISITOR_PERCENTAGE,
-    dataReloadRatio = PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD) {
-
-    const energyBycomponent = this.energyPerByteByComponent(bytes)
-    const cacheAdjustedSegmentEnergy = {}
+    dataReloadRatio = PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD
+  ) {
+    const energyBycomponent = this.energyPerByteByComponent(bytes);
+    const cacheAdjustedSegmentEnergy = {};
 
     for (const [key, value] of Object.entries(energyBycomponent)) {
       // represent the first load
-      cacheAdjustedSegmentEnergy[key] = value * firstView
+      cacheAdjustedSegmentEnergy[key] = value * firstView;
 
       // then represent the subsequent load
-      cacheAdjustedSegmentEnergy[key] += value * returnView * dataReloadRatio
+      cacheAdjustedSegmentEnergy[key] += value * returnView * dataReloadRatio;
     }
 
-    return cacheAdjustedSegmentEnergy
+    return cacheAdjustedSegmentEnergy;
   }
 
   /**
@@ -191,10 +191,12 @@ class SustainableWebDesign {
    */
   energyPerVisit(bytes) {
     // fetch the values using the default caching assumptions
-    const energyValues = Object.values(this.energyPerVisitByComponent(bytes))
+    const energyValues = Object.values(this.energyPerVisitByComponent(bytes));
 
     // return the summed of the values to return our single number
-    return energyValues.reduce((prevValue, currentValue) => prevValue + currentValue)
+    return energyValues.reduce(
+      (prevValue, currentValue) => prevValue + currentValue
+    );
   }
 
   emissionsPerVisitInGrams(energyPerVisit, carbonintensity = GLOBAL_INTENSITY) {

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -3,7 +3,7 @@
 /**
  * Sustainable Web Design
  *
- * Newly update calculations and figures from
+ * Updated calculations and figures from
  * https://sustainablewebdesign.org/calculating-digital-emissions/
  *
  *
@@ -11,26 +11,30 @@
 const { fileSize } = require("./constants");
 const { formatNumber } = require("./helpers");
 
-// Taken from: https://sustainablewebdesign.org/calculating-digital-emissions/#:~:text=TWh/EB%20or-,0.81%20kWH/GB,-Carbon%20factor%20(global
+// this refers to the estimated total energy use for the internet around 2000 TWh,
+// divided by the total transfer it enables around 2500 exabytes
 const KWH_PER_GB = 0.81;
-// Taken from: https://ember-climate.org/data/data-explorer
-// - Global carbon intensity for 2021
 
-const GLOBAL_INTENSITY = 442;
-// TODO add proper weighted average for non co2 emitting sources,
-// like wind, solar, hydro
-const RENEWABLES_INTENSITY = 0;
-
-// Taken from: https://gitlab.com/wholegrain/carbon-api-2-0/-/blob/master/includes/carbonapi.php
-const FIRST_TIME_VIEWING_PERCENTAGE = 0.25;
-const RETURNING_VISITOR_PERCENTAGE = 0.75;
-const PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD = 0.02;
-// Taken from: https://sustainablewebdesign.org/calculating-digital-emissions/#:~:text=Consumer%20device%20energy%20%3D%20AE%20x%200.52
-
+// these constants outline how the energy is attributed to
+// different parts of the system in the SWD model
 const END_USER_DEVICE_ENERGY = 0.52;
 const NETWORK_ENERGY = 0.14;
 const DATACENTER_ENERGY = 0.15;
 const PRODUCTION_ENERGY = 0.19;
+
+// These carbon intensity figures https://ember-climate.org/data/data-explorer
+// - Global carbon intensity for 2021
+const GLOBAL_INTENSITY = 442;
+const RENEWABLES_INTENSITY = 50;
+
+// Taken from: https://gitlab.com/wholegrain/carbon-api-2-0/-/blob/master/includes/carbonapi.php
+
+const FIRST_TIME_VIEWING_PERCENTAGE = 0.25;
+const RETURNING_VISITOR_PERCENTAGE = 0.75;
+const PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD = 0.02;
+
+
+
 
 class SustainableWebDesign {
   constructor(options) {
@@ -38,36 +42,146 @@ class SustainableWebDesign {
   }
 
   /**
-   * Accept a figure for bytes transferred and return a figure for CO2
-   * emissions. If transfer is for a domain served by renewables, return
-   * a figure to account for this
+   * Accept a figure for bytes transferred and return an object representing
+   * the share of the total enrgy use of the entire system, broken down
+   * by each corresponding system component
    *
-   * @param {Number} bytes
-   * @param {boolean} green
-   * @return {Number}
+   * @param {number}  bytes - the data transferred in bytes
+   * @return {object} Object containing the energy in kilowatt hours, keyed by system component
    */
-  perByte(bytes, green) {
+  energyPerByteByComponent(bytes) {
+
     const transferedBytesToGb = bytes / fileSize.GIGABYTE;
     const energyUsage = transferedBytesToGb * KWH_PER_GB;
-    return energyUsage * GLOBAL_INTENSITY;
+
+    // return the total energy, with breakdown by component
+    return {
+      consumerDeviceEnergy: energyUsage * END_USER_DEVICE_ENERGY,
+      networkEnergy: energyUsage * NETWORK_ENERGY,
+      productionEnergy: energyUsage * PRODUCTION_ENERGY,
+      dataCenterEnergy: energyUsage * DATACENTER_ENERGY,
+    }
+  }
+  /**
+   * Accept an object keys by the different system components, and
+   * return an object with the co2 figures key by the each component
+   *
+   * @param {object} energyBycomponent - energy grouped by the four system components
+   * @param {number} [carbonIntensity] - carbon intensity to apply to the datacentre values
+   * @return {number} the total number in grams of CO2 equivalent emissions
+   */
+  co2byComponent(energyBycomponent, carbonIntensity = GLOBAL_INTENSITY) {
+    const co2byComponent = {}
+    for (const [key, value] of Object.entries(energyBycomponent)) {
+      // we update the datacentre, as that's what we have information
+      // about.
+      if (key === 'dataCenterEnergy') {
+        co2byComponent[key] = value * carbonIntensity
+      } else {
+        // We don't have info about the device location,
+        // nor the network path used, nor the production emissions
+        // so we revert to global figures
+        co2byComponent[key] = value * GLOBAL_INTENSITY
+      }
+    }
+    return co2byComponent
   }
 
+  /**
+   * Accept a figure for bytes transferred and return a single figure for CO2
+   * emissions. Where information exists about the origin data is being
+   * fetched from, a different carbon intensity figure
+   * is applied for the datacentre share of the carbon intensity.
+   *
+   * @param {number} bytes - the data transferred in bytes
+   * @param {number} `carbonIntensity` the carbon intensity for datacentre (average figures, not marginal ones)
+   * @return {number} the total number in grams of CO2 equivalent emissions
+   */
+  perByte(bytes, carbonIntensity = GLOBAL_INTENSITY) {
+    const energyBycomponent = this.energyPerByteByComponent(bytes)
+
+    const co2byComponent = {}
+    for (const [key, value] of Object.entries(energyBycomponent)) {
+      // we update the datacentre, as that's what we have information
+      // about.
+      if (key === 'dataCenterEnergy') {
+        co2byComponent[key] = value * carbonIntensity
+      } else {
+        // We don't have info about the device location,
+        // nor the network path used, nor the production emissions
+        // so we revert to global figures
+        co2byComponent[key] = value * GLOBAL_INTENSITY
+      }
+    }
+
+    // pull out our values…
+    const co2Values = Object.values(co2byComponent)
+
+    // so we can return their sum
+    return co2Values.reduce((prevValue, currentValue) => prevValue + currentValue)
+  }
+
+
+  /**
+   * Accept a figure for bytes transferred and return the number of kilowatt hours used
+   * by the total system for this data transfer
+   *
+   * @param {number} bytes
+   * @return {number} the number of kilowatt hours used
+   */
+  energyPerByte(bytes) {
+    const energyByComponent = this.energyPerByteByComponent(bytes)
+
+    // pull out our values…
+    const energyValues = Object.values(energyByComponent)
+
+    // so we can return their sum
+    return energyValues.reduce((prevValue, currentValue) => prevValue + currentValue)
+  }
+
+  /**
+   * Accept a figure for bytes transferred, and return an object containing figures
+   * per system component, with the caching assumptions applied
+   *
+   * @param {number} bytes - the data transferred in bytes
+   * @return {object} Object containing the energy in kilowatt hours, keyed by system component
+   */
+  energyPerVisitByComponent(bytes,
+    firstView = FIRST_TIME_VIEWING_PERCENTAGE,
+    returnView = RETURNING_VISITOR_PERCENTAGE,
+    dataReloadRatio = PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD) {
+
+    const energyBycomponent = this.energyPerByteByComponent(bytes)
+    const cacheAdjustedSegmentEnergy = {}
+
+    for (const [key, value] of Object.entries(energyBycomponent)) {
+      // represent the first load
+      cacheAdjustedSegmentEnergy[key] = value * firstView
+
+      // then represent the subsequent load
+      cacheAdjustedSegmentEnergy[key] += value * returnView * dataReloadRatio
+    }
+
+    return cacheAdjustedSegmentEnergy
+  }
+
+  /**
+   * Accept a figure for bytes, and return the total figure for energy per visit
+   * using the default caching assumptions for loading a single website
+   *
+   * @param {number} bytes
+   * @return {number} the total energy use for the visit, after applying the caching assumptions
+   */
   energyPerVisit(bytes) {
-    const transferedBytesToGb = bytes / fileSize.GIGABYTE;
+    // fetch the values using the default caching assumptions
+    const energyValues = Object.values(this.energyPerVisitByComponent(bytes))
 
-    const newVisitorEnergy =
-      transferedBytesToGb * KWH_PER_GB * FIRST_TIME_VIEWING_PERCENTAGE;
-    const returningVisitorEnergy =
-      transferedBytesToGb *
-      KWH_PER_GB *
-      RETURNING_VISITOR_PERCENTAGE *
-      PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD;
-
-    return newVisitorEnergy + returningVisitorEnergy;
+    // return the summed of the values to return our single number
+    return energyValues.reduce((prevValue, currentValue) => prevValue + currentValue)
   }
 
-  emissionsPerVisitInGrams(energyPerVisit, globalIntensity = GLOBAL_INTENSITY) {
-    return formatNumber(energyPerVisit * globalIntensity);
+  emissionsPerVisitInGrams(energyPerVisit, carbonintensity = GLOBAL_INTENSITY) {
+    return formatNumber(energyPerVisit * carbonintensity);
   }
 
   annualEnergyInKwh(energyPerVisit, monthlyVisitors = 1000) {

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -113,7 +113,10 @@ class SustainableWebDesign {
       );
     }
 
-    const co2ValuesbyComponent = this.co2byComponent(energyBycomponent, carbonIntensity)
+    const co2ValuesbyComponent = this.co2byComponent(
+      energyBycomponent,
+      carbonIntensity
+    );
 
     // pull out our values…
     const co2Values = Object.values(co2ValuesbyComponent);

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -100,6 +100,23 @@ class SustainableWebDesign {
   perByte(bytes, carbonIntensity = GLOBAL_INTENSITY) {
     const energyBycomponent = this.energyPerByteByComponent(bytes)
 
+    // when faced with falsy values, fallback to global intensity
+    if (Boolean(carbonIntensity) === false) {
+      carbonIntensity = GLOBAL_INTENSITY
+    }
+    // if we have a boolean, we have a green result from the green web checker
+    // use the renewables intensity
+    if (carbonIntensity === true) {
+      carbonIntensity = RENEWABLES_INTENSITY
+    }
+
+    // otherwise when faced with non numeric values throw an error
+    if (typeof carbonIntensity !== 'number') {
+      throw new Error(
+        `perByte expects a numeric value or boolean for the carbon intensity value. Received: ${carbonIntensity}`
+      );
+    }
+
     const co2byComponent = {}
     for (const [key, value] of Object.entries(energyBycomponent)) {
       // we update the datacentre, as that's what we have information

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -16,13 +16,10 @@ const KWH_PER_GB = 0.81;
 // Taken from: https://ember-climate.org/data/data-explorer
 // - Global carbon intensity for 2021
 
-
-
 const GLOBAL_INTENSITY = 442;
 // TODO add proper weighted average for non co2 emitting sources,
 // like wind, solar, hydro
-const RENEWABLES_INTENSITY = 0
-
+const RENEWABLES_INTENSITY = 0;
 
 // Taken from: https://gitlab.com/wholegrain/carbon-api-2-0/-/blob/master/includes/carbonapi.php
 const FIRST_TIME_VIEWING_PERCENTAGE = 0.25;
@@ -32,15 +29,13 @@ const PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD = 0.02;
 
 const END_USER_DEVICE_ENERGY = 0.52;
 const NETWORK_ENERGY = 0.14;
-const DATACENTER_ENERGY = 0.15
-const PRODUCTION_ENERGY = 0.19
-
+const DATACENTER_ENERGY = 0.15;
+const PRODUCTION_ENERGY = 0.19;
 
 class SustainableWebDesign {
   constructor(options) {
     this.options = options;
   }
-
 
   /**
    * Accept a figure for bytes transferred and return a figure for CO2
@@ -53,11 +48,8 @@ class SustainableWebDesign {
    */
   perByte(bytes, green) {
     const transferedBytesToGb = bytes / fileSize.GIGABYTE;
-    const energyUsage = transferedBytesToGb * KWH_PER_GB
-    return energyUsage * GLOBAL_INTENSITY
-
-
-
+    const energyUsage = transferedBytesToGb * KWH_PER_GB;
+    return energyUsage * GLOBAL_INTENSITY;
   }
 
   energyPerVisit(bytes) {

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -4,11 +4,6 @@ describe("sustainable web design model", () => {
   const swd = new SustainableWebDesign();
   const averageWebsiteInBytes = 2257715.2;
 
-  // 950949.64224
-
-  // averageWebsite In gigabytes   0.00210266
-  // total energy transfer is 0.00170316 watt hours
-
   describe("energyPerByteByComponent", () => {
     it("should return a object with numbers for each system component", () => {
       const groupedEnergy = swd.energyPerByteByComponent(averageWebsiteInBytes);
@@ -21,7 +16,7 @@ describe("sustainable web design model", () => {
   });
 
   describe("energyPerByte", () => {
-    it("should return a number in watt hours for the given data transfer in bytes", () => {
+    it("should return a number in kilowatt hours for the given data transfer in bytes", () => {
       const energyForTransfer = swd.energyPerByte(averageWebsiteInBytes);
       expect(energyForTransfer).toBeCloseTo(0.00170316, 7);
     });

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -2,39 +2,36 @@ const SustainableWebDesign = require("./sustainable-web-design");
 
 describe("sustainable web design model", () => {
   const swd = new SustainableWebDesign();
-  const averageWebsiteInBytes = 2_257_715.2;
+  const averageWebsiteInBytes = 2257715.2;
 
   // 950949.64224
 
   // averageWebsite In gigabytes   0.00210266
   // total energy transfer is 0.00170316 watt hours
 
-
   describe("energyPerByteByComponent", () => {
     it("should return a object with numbers for each system component", () => {
-      const groupedEnergy = swd.energyPerByteByComponent(averageWebsiteInBytes)
+      const groupedEnergy = swd.energyPerByteByComponent(averageWebsiteInBytes);
 
-      expect(groupedEnergy.consumerDeviceEnergy).toBeCloseTo(0.00088564, 8)
-      expect(groupedEnergy.networkEnergy).toBeCloseTo(0.00023844, 8)
-      expect(groupedEnergy.productionEnergy).toBeCloseTo(0.0003236, 8)
-      expect(groupedEnergy.dataCenterEnergy).toBeCloseTo(0.00025547, 8)
+      expect(groupedEnergy.consumerDeviceEnergy).toBeCloseTo(0.00088564, 8);
+      expect(groupedEnergy.networkEnergy).toBeCloseTo(0.00023844, 8);
+      expect(groupedEnergy.productionEnergy).toBeCloseTo(0.0003236, 8);
+      expect(groupedEnergy.dataCenterEnergy).toBeCloseTo(0.00025547, 8);
     });
-  })
+  });
 
   describe("energyPerByte", () => {
     it("should return a number in watt hours for the given data transfer in bytes", () => {
-      const energyForTransfer = swd.energyPerByte(averageWebsiteInBytes)
-      expect(energyForTransfer).toBeCloseTo(0.00170316, 7)
-    })
-
-  })
+      const energyForTransfer = swd.energyPerByte(averageWebsiteInBytes);
+      expect(energyForTransfer).toBeCloseTo(0.00170316, 7);
+    });
+  });
 
   describe("perByte", () => {
     it("should return a single number for CO2 emissions", () => {
       expect(typeof swd.perByte(2257715.2)).toBe("number");
-
     });
-  })
+  });
 
   describe("energyPerVisit", function () {
     it("should return a number", () => {
@@ -42,7 +39,9 @@ describe("sustainable web design model", () => {
     });
 
     it("should calculate the correct energy", () => {
-      expect(swd.energyPerVisit(averageWebsiteInBytes)).toBe(0.0004513362121582032);
+      expect(swd.energyPerVisit(averageWebsiteInBytes)).toBe(
+        0.0004513362121582032
+      );
     });
   });
 

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -1,18 +1,48 @@
-const fs = require("fs");
-const path = require("path");
 const SustainableWebDesign = require("./sustainable-web-design");
 
 describe("sustainable web design model", () => {
   const swd = new SustainableWebDesign();
-  const averageWebsiteInBytes = 2257715.2;
+  const averageWebsiteInBytes = 2_257_715.2;
+
+  // 950949.64224
+
+  // averageWebsite In gigabytes   0.00210266
+  // total energy transfer is 0.00170316 watt hours
+
+
+  describe("energyPerByteByComponent", () => {
+    it("should return a object with numbers for each system component", () => {
+      const groupedEnergy = swd.energyPerByteByComponent(averageWebsiteInBytes)
+
+      expect(groupedEnergy.consumerDeviceEnergy).toBeCloseTo(0.00088564, 8)
+      expect(groupedEnergy.networkEnergy).toBeCloseTo(0.00023844, 8)
+      expect(groupedEnergy.productionEnergy).toBeCloseTo(0.0003236, 8)
+      expect(groupedEnergy.dataCenterEnergy).toBeCloseTo(0.00025547, 8)
+    });
+  })
+
+  describe("energyPerByte", () => {
+    it("should return a number in watt hours for the given data transfer in bytes", () => {
+      const energyForTransfer = swd.energyPerByte(averageWebsiteInBytes)
+      expect(energyForTransfer).toBeCloseTo(0.00170316, 7)
+    })
+
+  })
+
+  describe("perByte", () => {
+    it("should return a single number for CO2 emissions", () => {
+      expect(typeof swd.perByte(2257715.2)).toBe("number");
+
+    });
+  })
 
   describe("energyPerVisit", function () {
     it("should return a number", () => {
-      expect(typeof swd.energyPerVisit(2257715.2)).toBe("number");
+      expect(typeof swd.energyPerVisit(averageWebsiteInBytes)).toBe("number");
     });
 
     it("should calculate the correct energy", () => {
-      expect(swd.energyPerVisit(2257715.2)).toBe(0.0004513362121582032);
+      expect(swd.energyPerVisit(averageWebsiteInBytes)).toBe(0.0004513362121582032);
     });
   });
 


### PR DESCRIPTION
This PR updates our code structure and tests to support two models.

We'd ideally have the CO2 library demonstrating that there is a degree of compatibility across the two models, without duplicating too much logic across the two.

## TODO

- [x] Figure how to avoid duplicating test logic in the CO2 library that is calling methods on the models (i.e. perPage visit, perByte etc.)
- [x] Move logic from CO2 to the corresponding models if need be
- [x] Update tests for readability
- [x] Document methods that need it

While the tests pass, there is another PR open, #66, which addresses some of the numbers we're using, proposing we swap out some values for others ( i.e. gigabytes vs gibibytes).

I'd like to use that to review all the constants as I think some of the other carbon intensity numbers might need to be reviewed too.


