### PR TITLE
refactor(hosting): remove https package for fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "cross-fetch": "^3.1.5",
         "debug": "^4.1.1"
       },
       "devDependencies": {
@@ -1577,9 +1578,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -2426,6 +2427,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dependencies": {
+        "node-fetch": "2.6.7"
       }
     },
     "node_modules/cross-spawn": {
@@ -4050,9 +4059,9 @@
       }
     },
     "node_modules/inquirer-autosubmit-prompt/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -4258,9 +4267,9 @@
       }
     },
     "node_modules/inquirer-autosubmit-prompt/node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -5864,9 +5873,9 @@
       }
     },
     "node_modules/log-update/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6303,6 +6312,44 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-int64": {
@@ -7070,12 +7117,12 @@
       }
     },
     "node_modules/pagexray": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/pagexray/-/pagexray-4.3.1.tgz",
-      "integrity": "sha512-eVLrFwubv0gtggEy5HfunZwuluuapr/yd9oZK3fYLVLvBB6XqR77cxngS/nyPeRE/NjINX7gbSgwZd/75HKx+w==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/pagexray/-/pagexray-4.4.1.tgz",
+      "integrity": "sha512-vBl50PgflqBcb5w97vUGqYdA1o8TY5QOG7ec/sLkam5QngaVG0XlXwNP/Pm2kgCgu8I1pT+EAIqbcoDmDmsjeA==",
       "dev": true,
       "dependencies": {
-        "minimist": "1.2.5"
+        "minimist": "1.2.6"
       },
       "bin": {
         "pagexray": "bin/index.js"
@@ -7083,12 +7130,6 @@
       "engines": {
         "node": ">=8.9.0"
       }
-    },
-    "node_modules/pagexray/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -7292,15 +7333,6 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
@@ -8115,15 +8147,6 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10128,9 +10151,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -10776,6 +10799,14 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "requires": {
+        "node-fetch": "2.6.7"
       }
     },
     "cross-spawn": {
@@ -11995,9 +12026,9 @@
           "dev": true
         },
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
           "dev": true
         },
         "ansi-styles": {
@@ -12160,9 +12191,9 @@
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+              "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
               "dev": true
             }
           }
@@ -13399,9 +13430,9 @@
           "dev": true
         },
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
           "dev": true
         },
         "cli-cursor": {
@@ -13739,6 +13770,35 @@
       "dev": true,
       "requires": {
         "semver": "^7.3.5"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "node-int64": {
@@ -14309,20 +14369,12 @@
       }
     },
     "pagexray": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/pagexray/-/pagexray-4.3.1.tgz",
-      "integrity": "sha512-eVLrFwubv0gtggEy5HfunZwuluuapr/yd9oZK3fYLVLvBB6XqR77cxngS/nyPeRE/NjINX7gbSgwZd/75HKx+w==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/pagexray/-/pagexray-4.4.1.tgz",
+      "integrity": "sha512-vBl50PgflqBcb5w97vUGqYdA1o8TY5QOG7ec/sLkam5QngaVG0XlXwNP/Pm2kgCgu8I1pT+EAIqbcoDmDmsjeA==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
+        "minimist": "1.2.6"
       }
     },
     "parent-module": {
@@ -14472,12 +14524,6 @@
         "react-is": "^17.0.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -15091,14 +15137,6 @@
       "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        }
       }
     },
     "strip-bom": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "access": "public"
   },
   "dependencies": {
+    "cross-fetch": "^3.1.5",
     "debug": "^4.1.1"
   },
   "repository": {

--- a/src/hosting-api.js
+++ b/src/hosting-api.js
@@ -1,11 +1,11 @@
-'use strict';
+"use strict";
 
-const log = require('debug')('tgwf:hostingAPI');
-const fetch = require('cross-fetch');
+const log = require("debug")("tgwf:hostingAPI");
+const fetch = require("cross-fetch");
 
 function check(domain) {
   // is it a single domain or an array of them?
-  if (typeof domain === 'string') {
+  if (typeof domain === "string") {
     return checkAgainstAPI(domain);
   } else {
     return checkDomainsAgainstAPI(domain);

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -1,49 +1,49 @@
-const SustainableWebDesign = require('./sustainable-web-design');
+const SustainableWebDesign = require("./sustainable-web-design");
 
-describe('sustainable web design model', () => {
+describe("sustainable web design model", () => {
   const swd = new SustainableWebDesign();
   const averageWebsiteInBytes = 2257715.2;
 
-  describe('energyPerVisit', function () {
-    it('should return a number', () => {
-      expect(typeof swd.energyPerVisit(2257715.2)).toBe('number');
+  describe("energyPerVisit", function () {
+    it("should return a number", () => {
+      expect(typeof swd.energyPerVisit(2257715.2)).toBe("number");
     });
 
-    it('should calculate the correct energy', () => {
+    it("should calculate the correct energy", () => {
       expect(swd.energyPerVisit(2257715.2)).toBe(0.0004513362121582032);
     });
   });
 
-  describe('emissionsPerVisitInGrams', function () {
-    it('should calculate the correct co2 per visit', () => {
+  describe("emissionsPerVisitInGrams", function () {
+    it("should calculate the correct co2 per visit", () => {
       const averageWebsiteInBytes = 2257715.2;
       const energy = swd.energyPerVisit(averageWebsiteInBytes);
       expect(swd.emissionsPerVisitInGrams(energy)).toEqual(0.2);
     });
 
-    it('should accept a dynamic KwH value', () => {
+    it("should accept a dynamic KwH value", () => {
       const averageWebsiteInBytes = 2257715.2;
       const energy = swd.energyPerVisit(averageWebsiteInBytes);
       expect(swd.emissionsPerVisitInGrams(energy, 245)).toEqual(0.11);
     });
   });
 
-  describe('annualEnergyInKwh', function () {
-    it('should calculate the correct energy in kWh', () => {
+  describe("annualEnergyInKwh", function () {
+    it("should calculate the correct energy in kWh", () => {
       expect(swd.annualEnergyInKwh(averageWebsiteInBytes)).toBe(27092582400);
     });
   });
 
-  describe('annualEmissionsInGrams', function () {
-    it('should calculate the corrent energy in grams', () => {
+  describe("annualEmissionsInGrams", function () {
+    it("should calculate the corrent energy in grams", () => {
       expect(swd.annualEmissionsInGrams(averageWebsiteInBytes)).toBe(
         27092582400
       );
     });
   });
 
-  describe('annualSegmentEnergy', function () {
-    it('should return the correct values', () => {
+  describe("annualSegmentEnergy", function () {
+    it("should return the correct values", () => {
       expect(swd.annualSegmentEnergy(averageWebsiteInBytes)).toEqual({
         consumerDeviceEnergy: 1174011.9,
         dataCenterEnergy: 338657.28,

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -1,51 +1,49 @@
-const fs = require("fs");
-const path = require("path");
-const SustainableWebDesign = require("./sustainable-web-design");
+const SustainableWebDesign = require('./sustainable-web-design');
 
-describe("sustainable web design model", () => {
+describe('sustainable web design model', () => {
   const swd = new SustainableWebDesign();
   const averageWebsiteInBytes = 2257715.2;
 
-  describe("energyPerVisit", function () {
-    it("should return a number", () => {
-      expect(typeof swd.energyPerVisit(2257715.2)).toBe("number");
+  describe('energyPerVisit', function () {
+    it('should return a number', () => {
+      expect(typeof swd.energyPerVisit(2257715.2)).toBe('number');
     });
 
-    it("should calculate the correct energy", () => {
+    it('should calculate the correct energy', () => {
       expect(swd.energyPerVisit(2257715.2)).toBe(0.0004513362121582032);
     });
   });
 
-  describe("emissionsPerVisitInGrams", function () {
-    it("should calculate the correct co2 per visit", () => {
+  describe('emissionsPerVisitInGrams', function () {
+    it('should calculate the correct co2 per visit', () => {
       const averageWebsiteInBytes = 2257715.2;
       const energy = swd.energyPerVisit(averageWebsiteInBytes);
       expect(swd.emissionsPerVisitInGrams(energy)).toEqual(0.2);
     });
 
-    it("should accept a dynamic KwH value", () => {
+    it('should accept a dynamic KwH value', () => {
       const averageWebsiteInBytes = 2257715.2;
       const energy = swd.energyPerVisit(averageWebsiteInBytes);
       expect(swd.emissionsPerVisitInGrams(energy, 245)).toEqual(0.11);
     });
   });
 
-  describe("annualEnergyInKwh", function () {
-    it("should calculate the correct energy in kWh", () => {
+  describe('annualEnergyInKwh', function () {
+    it('should calculate the correct energy in kWh', () => {
       expect(swd.annualEnergyInKwh(averageWebsiteInBytes)).toBe(27092582400);
     });
   });
 
-  describe("annualEmissionsInGrams", function () {
-    it("should calculate the corrent energy in grams", () => {
+  describe('annualEmissionsInGrams', function () {
+    it('should calculate the corrent energy in grams', () => {
       expect(swd.annualEmissionsInGrams(averageWebsiteInBytes)).toBe(
         27092582400
       );
     });
   });
 
-  describe("annualSegmentEnergy", function () {
-    it("should return the correct values", () => {
+  describe('annualSegmentEnergy', function () {
+    it('should return the correct values', () => {
       expect(swd.annualSegmentEnergy(averageWebsiteInBytes)).toEqual({
         consumerDeviceEnergy: 1174011.9,
         dataCenterEnergy: 338657.28,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1395,6 +1395,13 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cross-fetch@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -3568,6 +3575,13 @@ node-abi@^3.3.0:
   dependencies:
     semver "^7.3.5"
 
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -4716,6 +4730,11 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
@@ -4907,6 +4926,11 @@ walker@^1.0.7:
   dependencies:
     makeerror "1.0.12"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -4928,6 +4952,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   version "8.7.0"


### PR DESCRIPTION
Removing the `https` package to use `cross-fetch` for both `node` and the `browser`