### PR TITLE
Redo the constants change - gibibyte to gigabyte calculations

### DIFF
--- a/src/constants/file-size.js
+++ b/src/constants/file-size.js
@@ -1,4 +1,4 @@
-const GIGABYTE = 1000 * 1000 * 1000;
+const GIGABYTE = 1024 * 1024 * 1024;
 
 module.exports = {
   GIGABYTE,

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -34,7 +34,9 @@ describe("sustainable web design model", () => {
     });
 
     it("should calculate the correct energy", () => {
-      expect(swd.energyPerVisit(2257715.2)).toBe(0.00048461856768000004);
+      expect(swd.energyPerVisit(averageWebsiteInBytes)).toBe(
+        0.0004513362121582032
+      );
     });
   });
 
@@ -42,13 +44,13 @@ describe("sustainable web design model", () => {
     it("should calculate the correct co2 per visit", () => {
       const averageWebsiteInBytes = 2257715.2;
       const energy = swd.energyPerVisit(averageWebsiteInBytes);
-      expect(swd.emissionsPerVisitInGrams(energy)).toEqual(0.21);
+      expect(swd.emissionsPerVisitInGrams(energy)).toEqual(0.2);
     });
 
     it("should accept a dynamic KwH value", () => {
       const averageWebsiteInBytes = 2257715.2;
       const energy = swd.energyPerVisit(averageWebsiteInBytes);
-      expect(swd.emissionsPerVisitInGrams(energy, 245)).toEqual(0.12);
+      expect(swd.emissionsPerVisitInGrams(energy, 245)).toEqual(0.11);
     });
   });
 


### PR DESCRIPTION
Reverts thegreenwebfoundation/co2.js#66

Oops. I shouldn't have merged that PR yet - I was tired last night and there are bunch of other tests this change affected.

This PR when ready, should make sure we're using the `1000 * 1000 * 1000` figure for gigabytes, but have all the tests passing.