### PR TITLE
refactor: replace unnamed functions with arrow callbacks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
     "ecmaVersion": 8
   },
   "plugins": ["prettier", "jest"],
-  "extends": "eslint:recommended",
+  "extends": ["eslint:recommended", "plugin:jest/recommended"],
   "rules": {
     "prettier/prettier": [
       "error",

--- a/src/1byte.test.js
+++ b/src/1byte.test.js
@@ -4,7 +4,7 @@ const oneByte = require("./1byte");
 
 describe("onebyte", () => {
   describe("perByte", () => {
-    it.only("returns a simple average of the different networks", () => {
+    it("returns a simple average of the different networks", () => {
       // we limit this to 12 figures with toFixed(12), because
       // we have a recurring 333333 afterwards
       // 4.88e-10 is the same as 0.000000000488

--- a/src/co2.js
+++ b/src/co2.js
@@ -45,9 +45,7 @@ class CO2 {
         transferSize: pageXray.domains[domain].transferSize,
       });
     }
-    co2PerDomain.sort(function (a, b) {
-      return b.co2 - a.co2;
-    });
+    co2PerDomain.sort((a, b) => b.co2 - a.co2);
 
     return co2PerDomain;
   }
@@ -93,9 +91,7 @@ class CO2 {
         transferSize: co2PerContentType[type].transferSize,
       });
     }
-    all.sort(function (a, b) {
-      return b.co2 - a.co2;
-    });
+    all.sort((a, b) => b.co2 - a.co2);
     return all;
   }
 
@@ -110,9 +106,7 @@ class CO2 {
       );
       allAssets.push({ url: asset.url, co2: co2ForTransfer, transferSize });
     }
-    allAssets.sort(function (a, b) {
-      return b.co2 - a.co2;
-    });
+    allAssets.sort((a, b) => b.co2 - a.co2);
 
     return allAssets.slice(0, allAssets.length > 10 ? 10 : allAssets.length);
   }

--- a/src/hosting-api.js
+++ b/src/hosting-api.js
@@ -36,12 +36,8 @@ async function checkDomainsAgainstAPI(domains) {
 
 function greenDomainsFromResults(greenResults) {
   const entries = Object.entries(greenResults);
-  let greenEntries = entries.filter(function ([key, val]) {
-    return val.green;
-  });
-  return greenEntries.map(function ([key, val]) {
-    return val.url;
-  });
+  const greenEntries = entries.filter(([key, val]) => val.green);
+  return greenEntries.map(([key, val]) => val.url);
 }
 
 async function getBody(url) {

--- a/src/hosting-database.test.js
+++ b/src/hosting-database.test.js
@@ -14,7 +14,7 @@ const dbPath = path.resolve(
 
 describe("hostingDatabase", () => {
   describe("checking a single domain with #check", () => {
-    test("tries to use a local database if available ", async () => {
+    test("tries to use a local database if available", async () => {
       const res = await hosting.check("google.com", dbPath);
       expect(res).toEqual(true);
     });

--- a/src/hosting-json.js
+++ b/src/hosting-json.js
@@ -49,13 +49,9 @@ function checkInJSON(domain, db) {
 
 function greenDomainsFromResults(greenResults) {
   const entries = Object.entries(greenResults);
-  let greenEntries = entries.filter(function ([key, val]) {
-    return val.green;
-  });
+  const greenEntries = entries.filter(([key, val]) => val.green);
 
-  return greenEntries.map(function ([key, val]) {
-    return val.url;
-  });
+  return greenEntries.map(([key, val]) => val.url);
 }
 
 function checkDomainsInJSON(domains, db) {

--- a/src/hosting-json.test.js
+++ b/src/hosting-json.test.js
@@ -24,8 +24,6 @@ describe("hostingJSON", () => {
       const res = await hosting.check("google.com", db);
       expect(res).toEqual(true);
     });
-  });
-  describe("checking a single domain with #check", () => {
     test("against the list of domains as JSON loaded from a gzipped JSON", async () => {
       const db = await hosting.loadJSON(jsonPathGz);
       const res = await hosting.check("google.com", db);

--- a/src/hosting.js
+++ b/src/hosting.js
@@ -14,13 +14,9 @@ function check(domain, db) {
 
 function greenDomainsFromResults(greenResults) {
   const entries = Object.entries(greenResults);
-  let greenEntries = entries.filter(function ([key, val]) {
-    return val.green;
-  });
+  const greenEntries = entries.filter(([key, val]) => val.green);
 
-  return greenEntries.map(function ([key, val]) {
-    return val.url;
-  });
+  return greenEntries.map(([key, val]) => val.url);
 }
 
 async function checkPage(pageXray, db) {

--- a/src/hosting.test.js
+++ b/src/hosting.test.js
@@ -45,7 +45,7 @@ describe("hosting", () => {
         "fonts.gstatic.com",
         "api.thegreenwebfoundation.org",
       ];
-      greenDomains.forEach(function (dom) {
+      greenDomains.forEach((dom) => {
         expect(expectedGreendomains).toContain(dom);
       });
     });

--- a/src/hosting.test.js
+++ b/src/hosting.test.js
@@ -24,8 +24,8 @@ describe("hosting", () => {
       )
     );
   });
-  describe("checking all domains on a page object with #checkPage ", () => {
-    it("it returns a list of green domains, when passed a page object", async () => {
+  describe("checking all domains on a page object with #checkPage", () => {
+    it("returns a list of green domains, when passed a page object", async () => {
       const pages = pagexray.convert(har);
       const pageXrayRun = pages[0];
       const db = await hosting.loadJSON(jsonPath);
@@ -49,9 +49,6 @@ describe("hosting", () => {
         expect(expectedGreendomains).toContain(dom);
       });
     });
-    // it(
-    //   'it returns an empty list, when passed a page object with no green domains'
-    // );
   });
   describe("checking a single domain with #check", () => {
     it("use the API instead", async () => {

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -42,13 +42,11 @@ describe("sustainable web design model", () => {
 
   describe("emissionsPerVisitInGrams", () => {
     it("should calculate the correct co2 per visit", () => {
-      const averageWebsiteInBytes = 2257715.2;
       const energy = swd.energyPerVisit(averageWebsiteInBytes);
       expect(swd.emissionsPerVisitInGrams(energy)).toEqual(0.2);
     });
 
     it("should accept a dynamic KwH value", () => {
-      const averageWebsiteInBytes = 2257715.2;
       const energy = swd.energyPerVisit(averageWebsiteInBytes);
       expect(swd.emissionsPerVisitInGrams(energy, 245)).toEqual(0.11);
     });

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -28,7 +28,7 @@ describe("sustainable web design model", () => {
     });
   });
 
-  describe("energyPerVisit", function () {
+  describe("energyPerVisit", () => {
     it("should return a number", () => {
       expect(typeof swd.energyPerVisit(averageWebsiteInBytes)).toBe("number");
     });
@@ -40,7 +40,7 @@ describe("sustainable web design model", () => {
     });
   });
 
-  describe("emissionsPerVisitInGrams", function () {
+  describe("emissionsPerVisitInGrams", () => {
     it("should calculate the correct co2 per visit", () => {
       const averageWebsiteInBytes = 2257715.2;
       const energy = swd.energyPerVisit(averageWebsiteInBytes);
@@ -54,13 +54,13 @@ describe("sustainable web design model", () => {
     });
   });
 
-  describe("annualEnergyInKwh", function () {
+  describe("annualEnergyInKwh", () => {
     it("should calculate the correct energy in kWh", () => {
       expect(swd.annualEnergyInKwh(averageWebsiteInBytes)).toBe(27092582400);
     });
   });
 
-  describe("annualEmissionsInGrams", function () {
+  describe("annualEmissionsInGrams", () => {
     it("should calculate the corrent energy in grams", () => {
       expect(swd.annualEmissionsInGrams(averageWebsiteInBytes)).toBe(
         27092582400
@@ -68,7 +68,7 @@ describe("sustainable web design model", () => {
     });
   });
 
-  describe("annualSegmentEnergy", function () {
+  describe("annualSegmentEnergy", () => {
     it("should return the correct values", () => {
       expect(swd.annualSegmentEnergy(averageWebsiteInBytes)).toEqual({
         consumerDeviceEnergy: 1174011.9,


### PR DESCRIPTION
This PR:

- Replaces unnamed functions with arrow callbacks; [arrow callbacks are already in use in the repo](https://github.com/thegreenwebfoundation/co2.js/blob/4a8737a5b33c4c68ee8581f4c9507e3b0503217a/src/helpers/index.js#L1), and this saves a few bits/bytes by using less loc
- Removes already declared variables in `sustainable-web-design.test.js`; `averageWebsiteInBytes` is declared further up in the scope on line 5
-  Enables the `eslint-plugin-jest` dev dependency rules in `.eslintrc.json` and fixes errors thrown by that plugin