### PR TITLE
ci: reduce workflow permissions to minimum

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
     - main
+permissions:
+    contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Declares the minimum [permissions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) for CI workflows to run at the workflow level, following principle of least privilege; see [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/)