### PR TITLE
chore(.npmignore): reduce package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,19 @@
+# Development and CI/CD config
+.github
+
+# Optional eslint cache
+.eslintcache
+
+# eslint config
+.eslintrc.json
+
+# Documentation
+images/
+
+# Test files
+src/**/*.test.js
+data/
+
+# Local sqlite db
 url2green.db
 url2green.json


### PR DESCRIPTION
This PR reduces the published package size from 5.6MB (17.0MB unpacked) to 14.0kB (42.3kB unpacked) by ignoring development and testing files.  The `./data/` directory contributed to most of this bloat and isn't used outside of test files.

You can see the package size by running `npm publish --dry-run`.