### PR TITLE
DW/double checking SWD calculations

### DIFF
--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -197,6 +197,18 @@ class SustainableWebDesign {
     );
   }
 
+  energyPerVisitV8(bytes) {
+    const transferedBytesToGb = bytes / fileSize.GIGABYTE;
+
+    return (
+      transferedBytesToGb * KWH_PER_GB * RETURNING_VISITOR_PERCENTAGE +
+      transferedBytesToGb *
+        KWH_PER_GB *
+        FIRST_TIME_VIEWING_PERCENTAGE *
+        PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD
+    );
+  }
+
   // TODO: this method looks like it applies the carbon intensity
   // change to the *entire* system, not just the datacenter.
   emissionsPerVisitInGrams(energyPerVisit, carbonintensity = GLOBAL_INTENSITY) {

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -197,6 +197,12 @@ class SustainableWebDesign {
     );
   }
 
+  /*
+   * JUST FOR TEST PURPOSES
+   * Testing v0.8.0 => v0.9.0 versions
+   *
+   *
+   */
   energyPerVisitV8(bytes) {
     const transferedBytesToGb = bytes / fileSize.GIGABYTE;
 

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -41,13 +41,17 @@ describe("sustainable web design model", () => {
 
     it("should match the old calculations", () => {
       // Test the v0.9.0 updates to the SWD method to identify differences
-      const currentCalculation = swd.energyPerVisit(averageWebsiteInBytes);
-      const oldCalulations = swd.energyPerVisitV8(averageWebsiteInBytes);
+      const currentEnergyCalc = swd.energyPerVisit(averageWebsiteInBytes);
+      const oldVersionEnergyCalc = swd.energyPerVisitV8(averageWebsiteInBytes);
 
-      expect(currentCalculation).toBe(0.0004513362121582032);
-      expect(oldCalulations).toBe(0.0004513362121582032);
+      expect(currentEnergyCalc).toBe(0.0004513362121582032);
+      expect(oldVersionEnergyCalc).toBe(0.0012858824157714846);
 
-      expect(oldCalulations).toBe(currentCalculation);
+      // Why do these values differ so much?
+      expect(oldVersionEnergyCalc).toBe(currentEnergyCalc);
+
+      expect(swd.emissionsPerVisitInGrams(currentEnergyCalc)).toEqual(0.57);
+      expect(swd.emissionsPerVisitInGrams(oldVersionEnergyCalc)).toEqual(0.2);
     });
   });
 

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -38,6 +38,17 @@ describe("sustainable web design model", () => {
         0.0004513362121582032
       );
     });
+
+    it("should match the old calculations", () => {
+      // Test the v0.9.0 updates to the SWD method to identify differences
+      const currentCalculation = swd.energyPerVisit(averageWebsiteInBytes);
+      const oldCalulations = swd.energyPerVisitV8(averageWebsiteInBytes);
+
+      expect(currentCalculation).toBe(0.0004513362121582032);
+      expect(oldCalulations).toBe(0.0004513362121582032);
+
+      expect(oldCalulations).toBe(currentCalculation);
+    });
   });
 
   describe("emissionsPerVisitInGrams", () => {


### PR DESCRIPTION
# Why/How have the calculations for SWD changed?

I've added this PR in to highlight and ask questions on why the SWD calculations have changed from `v0.8.0` to `v0.9.0`? To understand why, and do get these calculations double-checked by other people. 

With these updates, it takes CO2 grams per visit from `0.2` to `0.57` which is quite a jump. 

Some more info about the changes can be seen here: https://github.com/thegreenwebfoundation/co2.js/issues/76#issuecomment-1106232937
