### PR TITLE
Use base 10 (1000) vs base 2 (1024) for network calcs. Fixes #75

### DIFF
--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -151,12 +151,12 @@ describe("co2", () => {
     // we include more of the system in calculations for the
     // same levels of data transfer
     const MILLION = 1000000;
-    const MILLION_GREY = 0.33343;
-    const MILLION_GREEN = 0.28908;
+    const MILLION_GREY = 0.35802;
+    const MILLION_GREEN = 0.31039;
 
-    const TGWF_GREY_VALUE = 0.23501;
+    const TGWF_GREY_VALUE = 0.25234;
     const TGWF_GREEN_VALUE = 0.54704;
-    const TGWF_MIXED_VALUE = 0.20652;
+    const TGWF_MIXED_VALUE = 0.22175;
 
     beforeEach(() => {
       co2 = new CO2({ model: swd });

--- a/src/constants/file-size.js
+++ b/src/constants/file-size.js
@@ -1,4 +1,4 @@
-const GIGABYTE = 1024 * 1024 * 1024;
+const GIGABYTE = 1000 * 1000 * 1000;
 
 module.exports = {
   GIGABYTE,

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -8,17 +8,17 @@ describe("sustainable web design model", () => {
     it("should return a object with numbers for each system component", () => {
       const groupedEnergy = swd.energyPerByteByComponent(averageWebsiteInBytes);
 
-      expect(groupedEnergy.consumerDeviceEnergy).toBeCloseTo(0.00088564, 8);
-      expect(groupedEnergy.networkEnergy).toBeCloseTo(0.00023844, 8);
-      expect(groupedEnergy.productionEnergy).toBeCloseTo(0.0003236, 8);
-      expect(groupedEnergy.dataCenterEnergy).toBeCloseTo(0.00025547, 8);
+      expect(groupedEnergy.consumerDeviceEnergy).toBeCloseTo(0.00095095, 8);
+      expect(groupedEnergy.networkEnergy).toBeCloseTo(0.00025602, 7);
+      expect(groupedEnergy.productionEnergy).toBeCloseTo(0.0003475, 7);
+      expect(groupedEnergy.dataCenterEnergy).toBeCloseTo(0.00027431, 8);
     });
   });
 
   describe("energyPerByte", () => {
     it("should return a number in kilowatt hours for the given data transfer in bytes", () => {
       const energyForTransfer = swd.energyPerByte(averageWebsiteInBytes);
-      expect(energyForTransfer).toBeCloseTo(0.00170316, 7);
+      expect(energyForTransfer).toBeCloseTo(0.00182874, 7);
     });
   });
 
@@ -35,7 +35,7 @@ describe("sustainable web design model", () => {
 
     it("should calculate the correct energy", () => {
       expect(swd.energyPerVisit(averageWebsiteInBytes)).toBe(
-        0.001285882415771485
+        0.0013807057305600004
       );
     });
 
@@ -49,20 +49,20 @@ describe("sustainable web design model", () => {
 
       // with the constants switched around so the first view is 0.75, now 0.25
       // we should we the page come back at 0.57g not 0.2
-      expect(swd.emissionsPerVisitInGrams(v9currentEnergyCalc)).toEqual(0.57);
-      expect(swd.emissionsPerVisitInGrams(v8VersionEnergyCalc)).toEqual(0.2);
+      expect(swd.emissionsPerVisitInGrams(v9currentEnergyCalc)).toEqual(0.61);
+      expect(swd.emissionsPerVisitInGrams(v8VersionEnergyCalc)).toEqual(0.21);
     });
   });
 
   describe("emissionsPerVisitInGrams", () => {
     it("should calculate the correct co2 per visit", () => {
       const energy = swd.energyPerVisit(averageWebsiteInBytes);
-      expect(swd.emissionsPerVisitInGrams(energy)).toEqual(0.57);
+      expect(swd.emissionsPerVisitInGrams(energy)).toEqual(0.61);
     });
 
     it("should accept a dynamic KwH value", () => {
       const energy = swd.energyPerVisit(averageWebsiteInBytes);
-      expect(swd.emissionsPerVisitInGrams(energy, 245)).toEqual(0.32);
+      expect(swd.emissionsPerVisitInGrams(energy, 245)).toEqual(0.34);
     });
   });
 


### PR DESCRIPTION
This PR reintroduces the constants to use base 10 figures for calculations, so when we say Gigabyte we are referring to `1000 * 1000 * 1000 bytes`.

This is assuming the the original paper, when it refers to transfer in terms of gigabytes, is using the same calculation.

### What should this do to the calcs?

This should have the effect of making emissions figures  for every calculation go _up_ slightly, as the top down model that this is based on divides a set amount of energy use allocated to an entire system, then divides it by a very large number of gigabytes of transfer, to figure out a energy used for give amount of transfer.

By making the number we divide the total energy by smaller, we end up with higher energy use per byte, so we end up with higher numbers for carbon emissions as well.
