### PR TITLE
Allow switching of model to Sustainable Web Model using just a 'swd' string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > **Fixed** for any bug fixes.
 > **Security** in case of vulnerabilities.
 
+## Unreleased
+
+### Added
+
+- Added the ability to set the model used by CO2.js to the Sustainable Web Design model, using a simple 'swd' string, instead of needing to pass in a class.
+
+## 0.10.1 2022-08-01
+
+This release used a version bump as previously we had released v0.10.0 under a pre-release tag.
+
 ## 0.10.0 2022-06-27
 
 - Added ES import syntax as the main way for handling imports and exports of code within the module.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tgwf/co2",
-  "version": "0.9.0",
+  "version": "0.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tgwf/co2",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.3.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tgwf/co2",
-  "version": "0.9.0",
+  "version": "0.10.1",
   "description": "Work out the co2 of your digital services",
   "main": "dist/cjs/index-node.js",
   "module": "dist/esm/index.js",

--- a/src/co2.js
+++ b/src/co2.js
@@ -1,6 +1,7 @@
 "use strict";
 
 import OneByte from "./1byte.js";
+import SustainableWebDesign from "./sustainable-web-design.js"
 
 class CO2 {
   constructor(options) {
@@ -10,7 +11,14 @@ class CO2 {
     this.model = new OneByte();
 
     if (options) {
-      this.model = new options.model();
+      if (options.model === "swd") {
+        this.model = new SustainableWebDesign()
+      } else {
+        // retain the fallback for people developing
+        // new models that follow the same API
+        this.model = new options.model();
+      }
+
     }
   }
 

--- a/src/co2.js
+++ b/src/co2.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import OneByte from "./1byte.js";
-import SustainableWebDesign from "./sustainable-web-design.js"
+import SustainableWebDesign from "./sustainable-web-design.js";
 
 class CO2 {
   constructor(options) {
@@ -12,13 +12,12 @@ class CO2 {
 
     if (options) {
       if (options.model === "swd") {
-        this.model = new SustainableWebDesign()
+        this.model = new SustainableWebDesign();
       } else {
         // retain the fallback for people developing
         // new models that follow the same API
         this.model = new options.model();
       }
-
     }
   }
 

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -8,7 +8,6 @@ import pagexray from "pagexray";
 import CO2 from "./co2.js";
 import SustainableWebDesign from "./sustainable-web-design.js";
 
-
 describe("co2", () => {
   let har, co2;
 
@@ -161,7 +160,7 @@ describe("co2", () => {
     const TGWF_MIXED_VALUE = 0.22175;
 
     beforeEach(() => {
-      co2 = new CO2({ model: 'swd' });
+      co2 = new CO2({ model: "swd" });
       har = JSON.parse(
         fs.readFileSync(
           path.resolve(__dirname, "../data/fixtures/tgwf.har"),
@@ -312,7 +311,6 @@ describe("co2", () => {
           MILLION_GREY.toPrecision(5)
         );
       });
-    })
-  })
-
+    });
+  });
 });

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -6,7 +6,8 @@ import path from "path";
 import pagexray from "pagexray";
 
 import CO2 from "./co2.js";
-import swd from "./sustainable-web-design.js";
+import SustainableWebDesign from "./sustainable-web-design.js";
+
 
 describe("co2", () => {
   let har, co2;
@@ -147,7 +148,7 @@ describe("co2", () => {
     });
   });
 
-  describe("Sustainable Web Design model", () => {
+  describe("Sustainable Web Design model as simple option", () => {
     // the SWD model should have slightly higher values as
     // we include more of the system in calculations for the
     // same levels of data transfer
@@ -160,7 +161,7 @@ describe("co2", () => {
     const TGWF_MIXED_VALUE = 0.22175;
 
     beforeEach(() => {
-      co2 = new CO2({ model: swd });
+      co2 = new CO2({ model: 'swd' });
       har = JSON.parse(
         fs.readFileSync(
           path.resolve(__dirname, "../data/fixtures/tgwf.har"),
@@ -287,4 +288,31 @@ describe("co2", () => {
       });
     });
   });
+
+  describe("New model that implements the same API", () => {
+    const MILLION = 1000000;
+    const MILLION_GREY = 0.35802;
+
+    beforeEach(() => {
+      // we use the SustainableWebDesign to demonstrate passing
+      // in a complex object instead of a simple string
+      co2 = new CO2({ model: SustainableWebDesign });
+      har = JSON.parse(
+        fs.readFileSync(
+          path.resolve(__dirname, "../data/fixtures/tgwf.har"),
+          "utf8"
+        )
+      );
+    });
+
+    describe("perByte", () => {
+      it("returns a CO2 number for data transfer", () => {
+        co2.perByte(MILLION);
+        expect(co2.perByte(MILLION).toPrecision(5)).toBe(
+          MILLION_GREY.toPrecision(5)
+        );
+      });
+    })
+  })
+
 });


### PR DESCRIPTION
This PR introduces the ability to set the model used in CO2.js to use the Sustainable Web Model with a simple string, instead of you needing to add the object yourself.

Previously you might have needed to do this

```js
import CO2 from "./co2.js";
import SustainableWebDesign from "./sustainable-web-design.js";

const co2 = new CO2({ model: 'swd' });
```

This can be awkward when consuming the distributed package from npm if you want to try out the Sustainable Web Design model in some sample code, without checking out the repo, and we haven't defined an export map to point to various models.

With this change you can now do this:

```js
import CO2 from "./co2.js";
co2 = new CO2({ model: 'swd' });
```

This is much more helpful for using in notebooks, and things like Observable for quick demos.