### PR TITLE
Ensure OneByte model is used as default (for now)

### DIFF
--- a/src/co2.js
+++ b/src/co2.js
@@ -5,9 +5,11 @@ import SustainableWebDesign from "./sustainable-web-design.js";
 
 class CO2 {
   constructor(options) {
+    this.options = options;
+
     this.model = new OneByte();
     // Using optional chaining allows an empty object to be passed in without breaking the code.
-    if (options?.model === "swd") {
+    if (this.options?.model === "swd") {
       this.model = new SustainableWebDesign();
     }
   }


### PR DESCRIPTION
This PR ensures that the OneByte model is used as default when no `model` parameter is passed to the CO2 class. 