### PR TITLE
v0.11.0 - Use Sustainable web design model by default

### DIFF
--- a/src/co2.js
+++ b/src/co2.js
@@ -5,10 +5,12 @@ import SustainableWebDesign from "./sustainable-web-design.js";
 
 class CO2 {
   constructor(options) {
-    this.model = new OneByte();
+    this.model = new SustainableWebDesign();
     // Using optional chaining allows an empty object to be passed
     // in without breaking the code.
-    if (options?.model === "swd") {
+    if (options?.model === "1byte") {
+      this.model = new OneByte();
+    } else if (options?.model === "swd") {
       this.model = new SustainableWebDesign();
     }
   }

--- a/src/co2.js
+++ b/src/co2.js
@@ -12,6 +12,10 @@ class CO2 {
       this.model = new OneByte();
     } else if (options?.model === "swd") {
       this.model = new SustainableWebDesign();
+    } else if (options?.model) {
+      throw new Error(
+        `"${options.model}" is not a valid model. Please use "1byte" for the OneByte model, and "swd" for the Sustainable Web Design model.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`
+      );
     }
   }
 
@@ -41,10 +45,9 @@ class CO2 {
     if (this.model?.perVisit) {
       return this.model.perVisit(bytes, green);
     } else {
-      console.warn(
-        "The model you have selected does not support perVisit. Using perByte instead."
+      throw new Error(
+        `The perVisit() method is not supported in the model you are using. Try using perByte() instead.\nSee https://developers.thegreenwebfoundation.org/co2js/methods/ to learn more about the methods available in CO2.js.`
       );
-      return this.model.perByte(bytes, green);
     }
   }
 

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -46,16 +46,6 @@ describe("co2", () => {
       });
     });
 
-    // This test is to make sure that the fallback works.
-    // Since there is no perVisit fuction in the 1byte model, the perByte function is used.
-    describe("perVisit", () => {
-      it("returns a CO2 number for data transfer using 'grey' power", () => {
-        expect(co2.perVisit(MILLION).toPrecision(5)).toBe(
-          MILLION_GREY.toPrecision(5)
-        );
-      });
-    });
-
     describe("perPage", () => {
       it("returns CO2 for total transfer for page", () => {
         const pages = pagexray.convert(har);
@@ -316,6 +306,25 @@ describe("co2", () => {
           index++;
         }
       });
+    });
+  });
+
+  describe("Error checking", () => {
+    // Test for error if incorrect model is passed
+    it("throws an error if model is not valid", () => {
+      expect(() => (co2 = new CO2({ model: "1direction" }))).toThrowError(
+        `"1direction" is not a valid model. Please use "1byte" for the OneByte model, and "swd" for the Sustainable Web Design model.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`
+      );
+    });
+
+    // Test that an error is thrown when using the OneByte model with the perVisit method.
+    it("throws an error if perVisit method is not supported by model", () => {
+      expect(() => {
+        co2 = new CO2({ model: "1byte" });
+        co2.perVisit(10);
+      }).toThrowError(
+        `The perVisit() method is not supported in the model you are using. Try using perByte() instead.\nSee https://developers.thegreenwebfoundation.org/co2js/methods/ to learn more about the methods available in CO2.js.`
+      );
     });
   });
 });

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -6,7 +6,6 @@ import path from "path";
 import pagexray from "pagexray";
 
 import CO2 from "./co2.js";
-import SustainableWebDesign from "./sustainable-web-design.js";
 
 describe("co2", () => {
   let har, co2;

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -19,9 +19,8 @@ describe("co2", () => {
     const MILLION_GREY = 0.29081;
     const MILLION_GREEN = 0.23196;
 
-    // We're not passing in a model parameter here to ensure that 1byte gets used as default
     beforeEach(() => {
-      co2 = new CO2();
+      co2 = new CO2({ model: "1byte" });
       har = JSON.parse(
         fs.readFileSync(
           path.resolve(__dirname, "../data/fixtures/tgwf.har"),
@@ -171,9 +170,9 @@ describe("co2", () => {
     const TGWF_GREEN_VALUE = 0.54704;
     const TGWF_MIXED_VALUE = 0.22175;
 
-    // Passing in the SWD parameter here
+    // We're not passing in a model parameter here to check that SWD is used by default
     beforeEach(() => {
-      co2 = new CO2({ model: "swd" });
+      co2 = new CO2();
       har = JSON.parse(
         fs.readFileSync(
           path.resolve(__dirname, "../data/fixtures/tgwf.har"),


### PR DESCRIPTION
This PR switches the default model used by CO2.js from OneByte to the newer Sustainable Web Design (SWD) model.

Users can now use the use the SWD model in two ways:

1. By default `const emissions = new co2()`
2. Explicitly `const emissions = new co2({ model: "swd" })`

Uses who still wish to use the OneByte model may do so by passing it as a parameter when initiating a new CO2 object.

`const emissions = new co2({ model: "1byte" })`