### PR TITLE
ignore data files and public folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,18 +9,19 @@
 
 # Documentation
 images/
+public
 
 # Test files
 src/**/*.test.js
 
 # Data
 # exclude mode data
-data/
+data/**
 
 # but include the output js / json files
-!data/output/
+!data/output/**
 # and include the minimized versions
-!src/data/
+!src/data/**
 
 # Local sqlite db
 url2green.db


### PR DESCRIPTION
Recent v0.11.x updates to the library are coming in a 17MB + in size when published to NPM. This has been raised in #108 and it was found data files were being included in the published package.

This PR fixes that & also removes the `public` directory from the package, since it is only for demonstration purposes.