### PR TITLE
SWD adjustable constants update

### DIFF
--- a/src/co2.js
+++ b/src/co2.js
@@ -38,7 +38,10 @@
 import OneByte from "./1byte.js";
 import SustainableWebDesign from "./sustainable-web-design.js";
 
-import { GLOBAL_GRID_INTENSITY } from "./constants/index.js";
+import {
+  GLOBAL_GRID_INTENSITY,
+  RENEWABLES_GRID_INTENSITY,
+} from "./constants/index.js";
 import { parseOptions } from "./helpers/index.js";
 
 class CO2 {
@@ -126,14 +129,16 @@ class CO2 {
       variables: {
         description:
           "Below are the variables used to calculate this CO2 estimate.",
+        bytes,
         gridIntensity: {
           description:
             "The grid intensity (grams per kilowatt-hour) used to calculate this CO2 estimate.",
           network:
             adjustments?.gridIntensity?.network?.value || GLOBAL_GRID_INTENSITY,
-          dataCenter:
-            adjustments?.gridIntensity?.dataCenter?.value ||
-            GLOBAL_GRID_INTENSITY,
+          dataCenter: green
+            ? RENEWABLES_GRID_INTENSITY
+            : adjustments?.gridIntensity?.dataCenter?.value ||
+              GLOBAL_GRID_INTENSITY,
           production: GLOBAL_GRID_INTENSITY,
           device:
             adjustments?.gridIntensity?.device?.value || GLOBAL_GRID_INTENSITY,
@@ -171,15 +176,17 @@ class CO2 {
         variables: {
           description:
             "Below are the variables used to calculate this CO2 estimate.",
+          bytes,
           gridIntensity: {
             description:
               "The grid intensity (grams per kilowatt-hour) used to calculate this CO2 estimate.",
             network:
               adjustments?.gridIntensity?.network?.value ||
               GLOBAL_GRID_INTENSITY,
-            dataCenter:
-              adjustments?.gridIntensity?.dataCenter?.value ||
-              GLOBAL_GRID_INTENSITY,
+            dataCenter: green
+              ? RENEWABLES_GRID_INTENSITY
+              : adjustments?.gridIntensity?.dataCenter?.value ||
+                GLOBAL_GRID_INTENSITY,
             production: GLOBAL_GRID_INTENSITY,
             device:
               adjustments?.gridIntensity?.device?.value ||

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -68,10 +68,6 @@ class SustainableWebDesign {
     let dataCenterCarbonIntensity = GLOBAL_GRID_INTENSITY;
 
     let globalEmissions = GLOBAL_GRID_INTENSITY;
-    // If the user passes in a TRUE value (green web host), then use the renewables intensity value
-    if (carbonIntensity === true) {
-      dataCenterCarbonIntensity = RENEWABLES_GRID_INTENSITY;
-    }
 
     if (options?.gridIntensity) {
       const { device, network, dataCenter } = options.gridIntensity;
@@ -86,6 +82,11 @@ class SustainableWebDesign {
       if (dataCenter?.value) {
         dataCenterCarbonIntensity = dataCenter.value;
       }
+    }
+
+    // If the user passes in a TRUE value (green web host), then use the renewables intensity value
+    if (carbonIntensity === true) {
+      dataCenterCarbonIntensity = RENEWABLES_GRID_INTENSITY;
     }
 
     const returnCO2ByComponent = {};


### PR DESCRIPTION
This PR is a small update the recent adjustable constants in SWD PR #126.

In this PR there is one additional output, and one logic correction.

**Additional Output**

The `bytes` variable will also be returned as part of the `perVisitTrace` or `perByteTrace` results. This closes the loop, ensuring that all the inputs into the SWD formula are accounted for in the results.

```json
{
    "co2": 0.00027030509999999996,
    "green": false,
    "variables": {
      "description": "Below are the variables used to calculate this CO2 estimate.",
      "bytes": 1000,
      "gridIntensity": {
        "description": "The grid intensity (grams per kilowatt-hour) used to calculate this CO2 estimate.",
        "network": 442,
        "dataCenter": 442,
        "production": 442,
        "device": 442
      },
      "dataReloadRatio": 0.02,
      "firstVisitPercentage": 0.75,
      "returnVisitPercentage": 0.25
    }
  }
```

**Logic correction**

Now, when using `perVisitTrace` or `perByteTrace`, if the user sets the value for `green` as `true` then the calculation will us the renewable energy constant of 50 g/kWh in the calculation. This is regardless of if the user has also passed in a value for the `dataCenter` grid intensity separately.

For example:

- `perVisitTrace(1000, true, { gridIntensity: { dataCenter: 200 } })` would use the renewable grid intensity value of 50 g/kWh, **and not** the value of 200 g/kWh set by the user.
- `perVisitTrace(1000, false, { gridIntensity: { dataCenter: 200 } })` would use the value of 200 g/kWh set by the user.