### PR TITLE
Add a module declaration for use from typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module '@tgwf/co2';

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,2 @@
 declare module '@tgwf/co2';
+


### PR DESCRIPTION
Adding this module declaration means that importing co2 from typescript is possible with:

`import { co2 } from '@tgwf/co2'`