### PR TITLE
Add average intensity workflow

### DIFF
--- a/.github/workflows/update-average-intensities.yml
+++ b/.github/workflows/update-average-intensities.yml
@@ -1,7 +1,9 @@
 name: "Update average annual grid intensities"
 on:
   schedule:
-  - cron: "0 0 * * 1"
+  # https://crontab.guru/#0_10_1_*_*
+  # At 10:00 on day-of-month 1.
+  - cron: "0 10 1 * *"
   workflow_dispatch:
     inputs:
       logLevel:

--- a/.github/workflows/update-average-intensities.yml
+++ b/.github/workflows/update-average-intensities.yml
@@ -3,7 +3,7 @@ on:
   schedule:
   # https://crontab.guru/#0_10_1_*_*
   # At 10:00 on day-of-month 1.
-  - cron: "0 10 1 * *"
+  - cron: "0 10 3 * *"
   workflow_dispatch:
     inputs:
       logLevel:

--- a/.github/workflows/update-average-intensities.yml
+++ b/.github/workflows/update-average-intensities.yml
@@ -1,4 +1,4 @@
-name: "Update average co2 intensities"
+name: "Update average annual grid intensities"
 on:
   schedule:
   - cron: "0 0 * * 1"
@@ -22,14 +22,14 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Update report
+          commit-message: Update average annual grid intensities
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           signoff: false
           branch: average-intensities/${{ github.run_id }}
           delete-branch: true
-          title: '[generate_average_co2] Update report'
+          title: '[AUTOMATED] Update average annual grid intensities'
           body: |
-            - Updated average intensities
+            - Updated average annual grid intensities
             - Auto-generated `.github/workflows/update-average-intensities.yml` and `data/functions/generate_average_co2.js`
           draft: false

--- a/.github/workflows/update-average-intensities.yml
+++ b/.github/workflows/update-average-intensities.yml
@@ -17,7 +17,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run average intensities
-        run: node data/functions/generate_average_co2.js 
+        run: |
+          npm run intensity-data:average
+          npm run format-data
 
       - name: Create Pull Request
         id: cpr

--- a/.github/workflows/update-average-intensities.yml
+++ b/.github/workflows/update-average-intensities.yml
@@ -1,0 +1,35 @@
+name: "Update average co2 intensities"
+on:
+  schedule:
+  - cron: "0 0 * * 1"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'     
+        required: true
+        default: 'warning'
+jobs:
+  createPullRequest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run average intensities
+        run: node data/functions/generate_average_co2.js 
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update report
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          branch: average-intensities/${{ github.run_id }}
+          delete-branch: true
+          title: '[generate_average_co2] Update report'
+          body: |
+            - Updated average intensities
+            - Auto-generated `.github/workflows/update-average-intensities.yml` and `data/functions/generate_average_co2.js`
+          draft: false

--- a/data/functions/generate_average_co2.js
+++ b/data/functions/generate_average_co2.js
@@ -79,25 +79,24 @@ const type = "average";
     };
   });
 
-  const gridIntensityJson = JSON.stringify(gridIntensityResults);
-
   // This saves the country code and emissions data only, for use in the CO2.js library
   fs.writeFileSync(
     "data/output/average-intensities.js",
-    `const data = ${gridIntensityJson}; 
+    `const data = ${JSON.stringify(gridIntensityResults, null, "  ")}; 
 const type = "${type}";
 export { data, type }; 
-export default { data, type };`
+export default { data, type };
+`
   );
   // Save a minified version to the src folder so that it can be easily imported into the library
   fs.writeFileSync(
     "src/data/average-intensities.min.js",
-    `const data = ${gridIntensityJson}; const type = "${type}"; export { data, type }; export default { data, type };`
+    `const data = ${JSON.stringify(gridIntensityResults)}; const type = "${type}"; export { data, type }; export default { data, type };`
   );
 
   // This saves the full data set as a JSON file for reference.
   fs.writeFileSync(
     "data/output/average-intensities.json",
-    JSON.stringify(generalResults)
+    JSON.stringify(generalResults, null, "  ")
   );
 })();


### PR DESCRIPTION
This action runs `data/functions/generate_average_co2.js` which automatically updates the average intensity data.  It then creates a branch and pull request to merge updates. 

Looks like: 
![screenshot-github com-2023 05 25-14_14_29](https://github.com/thegreenwebfoundation/co2.js/assets/3211707/7b7f2155-1df7-4140-8511-6e3f4063c653)

Addresses: https://github.com/thegreenwebfoundation/co2.js/issues/143