### PR TITLE
Clean up SustainableWebDesign model `perByte` tests

### DIFF
--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -150,23 +150,6 @@ describe("co2", () => {
       );
     });
 
-    describe("perByte", () => {
-      it("returns a CO2 number for data transfer", () => {
-        co2.perByte(MILLION);
-        expect(co2.perByte(MILLION).toFixed(5)).toBe(MILLION_GREY.toFixed(5));
-      });
-
-      it("returns a lower CO2 number for data transfer from domains using entirely 'green' power", () => {
-        expect(co2.perByte(MILLION, false).toFixed(5)).toBe(
-          MILLION_GREY.toFixed(5)
-        );
-
-        expect(co2.perByte(MILLION, true).toFixed(5)).toBe(
-          MILLION_GREEN.toFixed(5)
-        );
-      });
-    });
-
     describe("perVisit", () => {
       it("returns a CO2 number for data transfer per visit with caching assumptions from the Sustainable Web Design model", () => {
         co2.perVisit(MILLION);

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -126,6 +126,10 @@ class SustainableWebDesign {
     segmentResults = false,
     options = {}
   ) {
+    if (bytes < 1) {
+      bytes = 0;
+    }
+
     const energyBycomponent = this.energyPerByteByComponent(bytes, options);
 
     // otherwise when faced with non numeric values throw an error

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -1,4 +1,5 @@
 import SustainableWebDesign from "./sustainable-web-design.js";
+import { MILLION, SWD } from "./constants/test-constants.js";
 
 describe("sustainable web design model", () => {
   const swd = new SustainableWebDesign();
@@ -26,8 +27,35 @@ describe("sustainable web design model", () => {
   });
 
   describe("perByte", () => {
-    it("should return a single number for CO2 emissions", () => {
-      expect(typeof swd.perByte(2257715.2)).toBe("number");
+    it("returns 0 for byte counts less than 1", () => {
+      expect(swd.perByte(0)).toBe(0);
+      expect(swd.perByte(0.99)).toBe(0);
+      expect(swd.perByte(-1)).toBe(0);
+
+      const segmented = swd.perByte(0.5, false, true);
+      expect(segmented.dataCenterCO2).toBe(0);
+      expect(segmented.consumerDeviceCO2).toBe(0);
+      expect(segmented.networkCO2).toBe(0);
+      expect(segmented.productionCO2).toBe(0);
+      expect(segmented.total).toBe(0);
+    });
+
+    it("returns a result for grey energy", () => {
+      expect(swd.perByte(MILLION)).toBeCloseTo(SWD.MILLION_GREY, 5);
+    });
+
+    it("returns a result for green energy", () => {
+      expect(swd.perByte(MILLION, true)).toBeCloseTo(SWD.MILLION_GREEN, 5);
+    });
+
+    it("can segment results", () => {
+      const result = swd.perByte(MILLION, false, true);
+
+      expect(result.dataCenterCO2).toBeCloseTo(0.05301, 5);
+      expect(result.consumerDeviceCO2).toBeCloseTo(0.18378, 5);
+      expect(result.networkCO2).toBeCloseTo(0.04948, 5);
+      expect(result.productionCO2).toBeCloseTo(0.06715, 5);
+      expect(result.total).toBeCloseTo(SWD.MILLION_GREY, 5);
     });
   });
 


### PR DESCRIPTION
This change:

- Adds more thorough tests for `SustainableWebDesign.prototype.perByte`
- Removes the associated tests from `co2.test.js`
- Makes a small functionality tweak: passing `perByte(n)` where `n` is less than 1 now behaves as if you called `perByte(0)`, similar to the existing `OneByte` model code

This is part of #98.