### PR TITLE
Store segment flag on CO2 instance, not models

### DIFF
--- a/src/co2.js
+++ b/src/co2.js
@@ -59,15 +59,8 @@ class CO2 {
       );
     }
 
-    if (options?.results === "segment") {
-      this.model.results = {
-        segment: true,
-      };
-    } else {
-      this.model.results = {
-        segment: false,
-      };
-    }
+    /** @private */
+    this._segment = options?.results === "segment";
   }
 
   /**
@@ -80,7 +73,7 @@ class CO2 {
    * @return {number} the amount of CO2 in grammes
    */
   perByte(bytes, green = false) {
-    return this.model.perByte(bytes, green, this.model.results.segment);
+    return this.model.perByte(bytes, green, this._segment);
   }
 
   /**
@@ -94,7 +87,7 @@ class CO2 {
    */
   perVisit(bytes, green = false) {
     if (this.model?.perVisit) {
-      return this.model.perVisit(bytes, green, this.model.results.segment);
+      return this.model.perVisit(bytes, green, this._segment);
     } else {
       throw new Error(
         `The perVisit() method is not supported in the model you are using. Try using perByte() instead.\nSee https://developers.thegreenwebfoundation.org/co2js/methods/ to learn more about the methods available in CO2.js.`
@@ -119,12 +112,7 @@ class CO2 {
       adjustments = parseOptions(options);
     }
     return {
-      co2: this.model.perByte(
-        bytes,
-        green,
-        this.model.results.segment,
-        adjustments
-      ),
+      co2: this.model.perByte(bytes, green, this._segment, adjustments),
       green,
       variables: {
         description:
@@ -166,12 +154,7 @@ class CO2 {
       }
 
       return {
-        co2: this.model.perVisit(
-          bytes,
-          green,
-          this.model.results.segment,
-          adjustments
-        ),
+        co2: this.model.perVisit(bytes, green, this._segment, adjustments),
         green,
         variables: {
           description:


### PR DESCRIPTION
No user impact is expected from this change.

Background: you can ask `CO2` to return segmented results by setting the `results` option to `"segment"`. The `CO2` instance stores this flag for later.

This changes where that flag is stored. Previously, it was stored as a public property of each model. This was unused by the model and is an unnecessary mutation.

Now, the property is stored on the `CO2` instance. I believe this is easier to follow. It should also make it possible to turn the models from stateful classes into stateless objects, simplifying the code (an idea that was discussed [years ago][0]).

This new flag is explicitly marked private with the [`@private` JSDoc tag][0] and implicitly marked private by prefixing its name with an underscore; a common JS convention. (I considered using [private class fields][1] instead, but browser support is new enough that this seemed risky.)

[0]: https://github.com/thegreenwebfoundation/co2.js/pull/12#issuecomment-593414891
[1]: https://jsdoc.app/tags-private.html
[2]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields