### PR TITLE
Use type definitions from DefinitelyTyped.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # CO2.js
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-13-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <img src="https://github.com/thegreenwebfoundation/co2.js/actions/workflows/unittests.yml/badge.svg" />
@@ -74,6 +76,14 @@ You can also build the CO2.js library from the source code. To do this:
    - `dist/cjs` - A CommonJS compatible build.
    - `dist/esm` - An ES Modules compatible build.
    - `dist/iife` - An Immediately Invoked Function Expression (IIFE) version of the library.
+
+## Using CO2.js in TypeScript projects
+
+Type definitions for CO2.js are published in the DefinitelyTyped project, and are available on NPM at `@types/tgwf__co2`.
+
+If you want to use type definitions in your project, they should be installed as a devDependency.
+
+`npm install --dev @types/tgwf__co2`
 
 ## Marginal and average emissions intensity data
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You can also build the CO2.js library from the source code. To do this:
    - `dist/esm` - An ES Modules compatible build.
    - `dist/iife` - An Immediately Invoked Function Expression (IIFE) version of the library.
 
-## Using CO2.js in TypeScript projects
+## TypeScript support
 
 Type definitions for CO2.js are [published in the DefinitelyTyped project](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/tgwf__co2), and are [available on NPM](https://www.npmjs.com/package/@types/tgwf__co2) at `@types/tgwf__co2`.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can also build the CO2.js library from the source code. To do this:
 
 ## Using CO2.js in TypeScript projects
 
-Type definitions for CO2.js are published in the DefinitelyTyped project, and are available on NPM at `@types/tgwf__co2`.
+Type definitions for CO2.js are [published in the DefinitelyTyped project](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/tgwf__co2), and are [available on NPM](https://www.npmjs.com/package/@types/tgwf__co2) at `@types/tgwf__co2`.
 
 If you want to use type definitions in your project, they should be installed as a devDependency.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,0 @@
-declare module '@tgwf/co2';
-


### PR DESCRIPTION
The PR removes current index.d.ts file that ships with this project, and provides guidance on how to install types as a devDependency from NPM.

This closes off #77, and removes the need for further work in #168.