### PR TITLE
Add Sustainable Web Design rating scale

### DIFF
--- a/src/1byte.js
+++ b/src/1byte.js
@@ -39,6 +39,7 @@ const KWH_PER_BYTE_FOR_DEVICES = 1.3e-10;
 
 class OneByte {
   constructor(options) {
+    this.allowRatings = false;
     this.options = options;
 
     this.KWH_PER_BYTE_FOR_NETWORK = KWH_PER_BYTE_FOR_NETWORK;

--- a/src/co2.js
+++ b/src/co2.js
@@ -68,14 +68,17 @@ import { parseOptions } from "./helpers/index.js";
 
 class CO2 {
   constructor(options) {
+    let allowRatings = true;
     this.model = new SustainableWebDesign();
     // Using optional chaining allows an empty object to be passed
     // in without breaking the code.
     if (options?.model === "1byte") {
       this.model = new OneByte();
+      allowRatings = false;
     } else if (options?.model === "swd") {
       this.model = new SustainableWebDesign();
     } else if (options?.model) {
+      allowRatings = false;
       throw new Error(
         `"${options.model}" is not a valid model. Please use "1byte" for the OneByte model, and "swd" for the Sustainable Web Design model.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`
       );
@@ -86,7 +89,7 @@ class CO2 {
     this._rating = options?.rating === true;
 
     // The rating system is only supported in the Sustainable Web Design Model.
-    if (options?.model !== "swd" && this._rating) {
+    if (!allowRatings && this._rating) {
       throw new Error(
         `The rating system is not supported in the model you are using. Try using the Sustainable Web Design model instead.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`
       );
@@ -103,7 +106,7 @@ class CO2 {
    * @return {number|CO2EstimateComponentsPerByte} the amount of CO2 in grammes or its separate components
    */
   perByte(bytes, green = false) {
-    return this.model.perByte(bytes, green, this._segment);
+    return this.model.perByte(bytes, green, this._segment, this._rating);
   }
 
   /**
@@ -117,7 +120,7 @@ class CO2 {
    */
   perVisit(bytes, green = false) {
     if (this.model?.perVisit) {
-      return this.model.perVisit(bytes, green, this._segment);
+      return this.model.perVisit(bytes, green, this._segment, this._rating);
     } else {
       throw new Error(
         `The perVisit() method is not supported in the model you are using. Try using perByte() instead.\nSee https://developers.thegreenwebfoundation.org/co2js/methods/ to learn more about the methods available in CO2.js.`
@@ -142,7 +145,13 @@ class CO2 {
       adjustments = parseOptions(options);
     }
     return {
-      co2: this.model.perByte(bytes, green, this._segment, adjustments),
+      co2: this.model.perByte(
+        bytes,
+        green,
+        this._segment,
+        this._rating,
+        adjustments
+      ),
       green,
       variables: {
         description:
@@ -184,7 +193,13 @@ class CO2 {
       }
 
       return {
-        co2: this.model.perVisit(bytes, green, this._segment, adjustments),
+        co2: this.model.perVisit(
+          bytes,
+          green,
+          this._segment,
+          this._rating,
+          adjustments
+        ),
         green,
         variables: {
           description:

--- a/src/co2.js
+++ b/src/co2.js
@@ -83,6 +83,14 @@ class CO2 {
 
     /** @private */
     this._segment = options?.results === "segment";
+    this._rating = options?.rating === true;
+
+    // The rating system is only supported in the Sustainable Web Design Model.
+    if (options?.model !== "swd" && this._rating) {
+      throw new Error(
+        `The rating system is not supported in the model you are using. Try using the Sustainable Web Design model instead.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`
+      );
+    }
   }
 
   /**

--- a/src/co2.js
+++ b/src/co2.js
@@ -41,6 +41,7 @@
  * @property {number} dataCenterCO2 - The CO2 estimate for data centers in grams
  * @property {number} consumerDeviceCO2 - The CO2 estimate for consumer devices in grams
  * @property {number} productionCO2 - The CO2 estimate for device production in grams
+ * @property {string} rating - The rating of the CO2 estimate based on the Sustainable Web Design Model
  * @property {number} total - The total CO2 estimate in grams
  */
 
@@ -54,6 +55,7 @@
  * @property {number} 'consumerDeviceCO2 - subsequent' - The CO2 estimate for consumer devices in grams on subsequent visits
  * @property {number} 'productionCO2 - first' - The CO2 estimate for device production in grams on first visit
  * @property {number} 'productionCO2 - subsequent' - The CO2 estimate for device production in grams on subsequent visits
+ * @property {string} rating - The rating of the CO2 estimate based on the Sustainable Web Design Model
  * @property {number} total - The total CO2 estimate in grams
  */
 

--- a/src/co2.js
+++ b/src/co2.js
@@ -68,24 +68,31 @@ import { parseOptions } from "./helpers/index.js";
 
 class CO2 {
   constructor(options) {
-    let allowRatings = true;
     this.model = new SustainableWebDesign();
     // Using optional chaining allows an empty object to be passed
     // in without breaking the code.
     if (options?.model === "1byte") {
       this.model = new OneByte();
-      allowRatings = false;
     } else if (options?.model === "swd") {
       this.model = new SustainableWebDesign();
     } else if (options?.model) {
-      allowRatings = false;
       throw new Error(
         `"${options.model}" is not a valid model. Please use "1byte" for the OneByte model, and "swd" for the Sustainable Web Design model.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`
       );
     }
 
+    if (options?.rating && typeof options.rating !== "boolean") {
+      throw new Error(
+        `The rating option must be a boolean. Please use true or false.\nSee https://developers.thegreenwebfoundation.org/co2js/options/ to learn more about the options available in CO2.js.`
+      );
+    }
+
+    // This flag checks to see if the model itself has a rating system.
+    const allowRatings = !!this.model.allowRatings;
+
     /** @private */
     this._segment = options?.results === "segment";
+    // This flag is set by the user to enable the rating system.
     this._rating = options?.rating === true;
 
     // The rating system is only supported in the Sustainable Web Design Model.

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -211,6 +211,14 @@ describe("co2", () => {
         `The perVisit() method is not supported in the model you are using. Try using perByte() instead.\nSee https://developers.thegreenwebfoundation.org/co2js/methods/ to learn more about the methods available in CO2.js.`
       );
     });
+
+    it("throws an error if using the rating system with OneByte", () => {
+      expect(() => {
+        co2 = new CO2({ model: "1byte", rating: true });
+      }).toThrowError(
+        `The rating system is not supported in the model you are using. Try using the Sustainable Web Design model instead.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`
+      );
+    });
   });
 
   // Test that grid intensity data can be imported and used

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -219,6 +219,14 @@ describe("co2", () => {
         `The rating system is not supported in the model you are using. Try using the Sustainable Web Design model instead.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`
       );
     });
+
+    it("throws an error if the rating parameter is not a boolean", () => {
+      expect(() => {
+        co2 = new CO2({ rating: "false" });
+      }).toThrowError(
+        `The rating option must be a boolean. Please use true or false.\nSee https://developers.thegreenwebfoundation.org/co2js/options/ to learn more about the options available in CO2.js.`
+      );
+    });
   });
 
   // Test that grid intensity data can be imported and used

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -840,4 +840,23 @@ describe("co2", () => {
       expect(co2Result["consumerDeviceCO2 - subsequent"]).toBe(0);
     });
   });
+
+  describe("Returning SWD results with rating", () => {
+    const co2NoRating = new CO2();
+    const co2Rating = new CO2({ rating: true });
+    const co2RatingSegmented = new CO2({ rating: true, results: "segment" });
+
+    it("does not return a rating when rating is false", () => {
+      expect(co2NoRating.perVisit(MILLION)).not.toHaveProperty("rating");
+    });
+
+    it("returns a rating when rating is true", () => {
+      expect(co2Rating.perVisit(MILLION)).toHaveProperty("rating");
+    });
+
+    it("returns a rating when rating is true and results are segmented", () => {
+      expect(co2RatingSegmented.perByte(MILLION)).toHaveProperty("rating");
+      expect(co2RatingSegmented.perByte(MILLION)).toHaveProperty("networkCO2");
+    });
+  });
 });

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -24,6 +24,15 @@ const FIRST_TIME_VIEWING_PERCENTAGE = 0.75;
 const RETURNING_VISITOR_PERCENTAGE = 0.25;
 const PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD = 0.02;
 
+const SWDMv3Ratings = {
+  fifthPercentile: 0.095,
+  tenthPercentile: 0.186,
+  twentiethPercentile: 0.341,
+  thirtiethPercentile: 0.493,
+  fortiethPercentile: 0.656,
+  fiftiethPercentile: 0.846,
+};
+
 export {
   fileSize,
   KWH_PER_GB,
@@ -36,4 +45,5 @@ export {
   FIRST_TIME_VIEWING_PERCENTAGE,
   RETURNING_VISITOR_PERCENTAGE,
   PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD,
+  SWDMv3Ratings,
 };

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -17,6 +17,8 @@ import {
 
 const formatNumber = (num) => parseFloat(num.toFixed(2));
 
+const lessThan = (num, limit) => num < limit;
+
 function parseOptions(options) {
   // CHeck that it is an object
   if (typeof options !== "object") {
@@ -192,4 +194,4 @@ function getApiRequestHeaders(comment = "") {
   return { "User-Agent": `co2js/${process.env.CO2JS_VERSION} ${comment}` };
 }
 
-export { formatNumber, parseOptions, getApiRequestHeaders };
+export { formatNumber, parseOptions, getApiRequestHeaders, lessThan };

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -17,7 +17,7 @@ import {
 
 const formatNumber = (num) => parseFloat(num.toFixed(2));
 
-const lessThan = (num, limit) => num < limit;
+const lessThanEqualTo = (num, limit) => num <= limit;
 
 function parseOptions(options) {
   // CHeck that it is an object
@@ -194,4 +194,4 @@ function getApiRequestHeaders(comment = "") {
   return { "User-Agent": `co2js/${process.env.CO2JS_VERSION} ${comment}` };
 }
 
-export { formatNumber, parseOptions, getApiRequestHeaders, lessThan };
+export { formatNumber, parseOptions, getApiRequestHeaders, lessThanEqualTo };

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -130,6 +130,7 @@ class SustainableWebDesign {
    * @param {number} bytes - the data transferred in bytes
    * @param {boolean} carbonIntensity - a boolean indicating whether the data center is green or not
    * @param {boolean} segmentResults - a boolean indicating whether to return the results broken down by component
+   * @param {boolean} ratingResults - a boolean indicating whether to return the rating based on the Sustainable Web Design Model
    * @param {object} options - an object containing the grid intensity and first/return visitor values
    * @return {number|object} the total number in grams of CO2 equivalent emissions, or an object containing the breakdown by component
    */
@@ -196,6 +197,7 @@ class SustainableWebDesign {
    * @param {number} bytes - the data transferred in bytes
    * @param {boolean} carbonIntensity - a boolean indicating whether the data center is green or not
    * @param {boolean} segmentResults - a boolean indicating whether to return the results broken down by component
+   * @param {boolean} ratingResults - a boolean indicating whether to return the rating based on the Sustainable Web Design Model
    * @param {object} options - an object containing the grid intensity and first/return visitor values
    * @return {number|object} the total number in grams of CO2 equivalent emissions, or an object containing the breakdown by component
    */
@@ -378,6 +380,12 @@ class SustainableWebDesign {
     };
   }
 
+  /**
+   * Determines the rating of a website's sustainability based on its CO2 emissions.
+   *
+   * @param {number} co2e - The CO2 emissions of the website in grams.
+   * @returns {string} The sustainability rating, ranging from "A+" (best) to "F" (worst).
+   */
   ratingScale(co2e) {
     if (lessThanEqualTo(co2e, fifthPercentile)) {
       return "A+";

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -35,6 +35,7 @@ const {
 
 class SustainableWebDesign {
   constructor(options) {
+    this.allowRatings = true;
     this.options = options;
   }
 

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -20,8 +20,18 @@ import {
   FIRST_TIME_VIEWING_PERCENTAGE,
   RETURNING_VISITOR_PERCENTAGE,
   PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD,
+  SWDMv3Ratings,
 } from "./constants/index.js";
 import { formatNumber, lessThanEqualTo } from "./helpers/index.js";
+
+const {
+  fifthPercentile,
+  tenthPercentile,
+  twentiethPercentile,
+  thirtiethPercentile,
+  fortiethPercentile,
+  fiftiethPercentile,
+} = SWDMv3Ratings;
 
 class SustainableWebDesign {
   constructor(options) {
@@ -368,17 +378,17 @@ class SustainableWebDesign {
   }
 
   ratingScale(co2e) {
-    if (lessThanEqualTo(co2e, 0.095)) {
+    if (lessThanEqualTo(co2e, fifthPercentile)) {
       return "A+";
-    } else if (lessThanEqualTo(co2e, 0.186)) {
+    } else if (lessThanEqualTo(co2e, tenthPercentile)) {
       return "A";
-    } else if (lessThanEqualTo(co2e, 0.341)) {
+    } else if (lessThanEqualTo(co2e, twentiethPercentile)) {
       return "B";
-    } else if (lessThanEqualTo(co2e, 0.493)) {
+    } else if (lessThanEqualTo(co2e, thirtiethPercentile)) {
       return "C";
-    } else if (lessThanEqualTo(co2e, 0.656)) {
+    } else if (lessThanEqualTo(co2e, fortiethPercentile)) {
       return "D";
-    } else if (lessThanEqualTo(co2e, 0.846)) {
+    } else if (lessThanEqualTo(co2e, fiftiethPercentile)) {
       return "E";
     } else {
       return "F";

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -126,6 +126,7 @@ class SustainableWebDesign {
     bytes,
     carbonIntensity = false,
     segmentResults = false,
+    ratingResults = false,
     options = {}
   ) {
     if (bytes < 1) {
@@ -153,8 +154,25 @@ class SustainableWebDesign {
       (prevValue, currentValue) => prevValue + currentValue
     );
 
+    let rating = null;
+    if (ratingResults) {
+      rating = this.ratingScale(bytes);
+    }
+
     if (segmentResults) {
+      if (ratingResults) {
+        return {
+          ...co2ValuesbyComponent,
+          total: co2ValuesSum,
+          rating: rating,
+        };
+      }
+
       return { ...co2ValuesbyComponent, total: co2ValuesSum };
+    }
+
+    if (ratingResults) {
+      return { total: co2ValuesSum, rating: rating };
     }
 
     return co2ValuesSum;
@@ -174,6 +192,7 @@ class SustainableWebDesign {
     bytes,
     carbonIntensity = false,
     segmentResults = false,
+    ratingResults = false,
     options = {}
   ) {
     const energyBycomponent = this.energyPerVisitByComponent(bytes, options);
@@ -197,8 +216,24 @@ class SustainableWebDesign {
       (prevValue, currentValue) => prevValue + currentValue
     );
 
+    let rating = null;
+    if (ratingResults) {
+      rating = this.ratingScale(bytes);
+    }
+
     if (segmentResults) {
+      if (ratingResults) {
+        return {
+          ...co2ValuesbyComponent,
+          total: co2ValuesSum,
+          rating: rating,
+        };
+      }
       return { ...co2ValuesbyComponent, total: co2ValuesSum };
+    }
+
+    if (ratingResults) {
+      return { total: co2ValuesSum, rating: rating };
     }
 
     // so we can return their sum

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -21,7 +21,7 @@ import {
   RETURNING_VISITOR_PERCENTAGE,
   PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD,
 } from "./constants/index.js";
-import { formatNumber, lessThan } from "./helpers/index.js";
+import { formatNumber, lessThanEqualTo } from "./helpers/index.js";
 
 class SustainableWebDesign {
   constructor(options) {
@@ -156,7 +156,7 @@ class SustainableWebDesign {
 
     let rating = null;
     if (ratingResults) {
-      rating = this.ratingScale(bytes);
+      rating = this.ratingScale(co2ValuesSum);
     }
 
     if (segmentResults) {
@@ -218,7 +218,7 @@ class SustainableWebDesign {
 
     let rating = null;
     if (ratingResults) {
-      rating = this.ratingScale(bytes);
+      rating = this.ratingScale(co2ValuesSum);
     }
 
     if (segmentResults) {
@@ -367,18 +367,18 @@ class SustainableWebDesign {
     };
   }
 
-  ratingScale(bytes) {
-    if (lessThan(bytes, 272510)) {
+  ratingScale(co2e) {
+    if (lessThanEqualTo(co2e, 0.095)) {
       return "A+";
-    } else if (lessThan(bytes, 531150)) {
+    } else if (lessThanEqualTo(co2e, 0.186)) {
       return "A";
-    } else if (lessThan(bytes, 975850)) {
+    } else if (lessThanEqualTo(co2e, 0.341)) {
       return "B";
-    } else if (lessThan(bytes, 1410390)) {
+    } else if (lessThanEqualTo(co2e, 0.493)) {
       return "C";
-    } else if (lessThan(bytes, 1875010)) {
+    } else if (lessThanEqualTo(co2e, 0.656)) {
       return "D";
-    } else if (lessThan(bytes, 2419560)) {
+    } else if (lessThanEqualTo(co2e, 0.846)) {
       return "E";
     } else {
       return "F";

--- a/src/sustainable-web-design.js
+++ b/src/sustainable-web-design.js
@@ -21,7 +21,7 @@ import {
   RETURNING_VISITOR_PERCENTAGE,
   PERCENTAGE_OF_DATA_LOADED_ON_SUBSEQUENT_LOAD,
 } from "./constants/index.js";
-import { formatNumber } from "./helpers/index.js";
+import { formatNumber, lessThan } from "./helpers/index.js";
 
 class SustainableWebDesign {
   constructor(options) {
@@ -330,6 +330,24 @@ class SustainableWebDesign {
       dataCenterEnergy: formatNumber(annualEnergy * DATACENTER_ENERGY),
       productionEnergy: formatNumber(annualEnergy * PRODUCTION_ENERGY),
     };
+  }
+
+  ratingScale(bytes) {
+    if (lessThan(bytes, 272510)) {
+      return "A+";
+    } else if (lessThan(bytes, 531150)) {
+      return "A";
+    } else if (lessThan(bytes, 975850)) {
+      return "B";
+    } else if (lessThan(bytes, 1410390)) {
+      return "C";
+    } else if (lessThan(bytes, 1875010)) {
+      return "D";
+    } else if (lessThan(bytes, 2419560)) {
+      return "E";
+    } else {
+      return "F";
+    }
   }
 }
 

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -1,5 +1,15 @@
 import SustainableWebDesign from "./sustainable-web-design.js";
 import { MILLION, SWD } from "./constants/test-constants.js";
+import { SWDMv3Ratings } from "./constants/index.js";
+
+const {
+  fifthPercentile,
+  tenthPercentile,
+  twentiethPercentile,
+  thirtiethPercentile,
+  fortiethPercentile,
+  fiftiethPercentile,
+} = SWDMv3Ratings;
 
 describe("sustainable web design model", () => {
   const swd = new SustainableWebDesign();
@@ -125,9 +135,9 @@ describe("sustainable web design model", () => {
     });
 
     it("returns ratings as expected", () => {
-      expect(swd.ratingScale(0.065)).toBe("A+");
-      expect(swd.ratingScale(0.342)).toBe("C");
-      expect(swd.ratingScale(0.341)).toBe("B");
+      expect(swd.ratingScale(fifthPercentile)).toBe("A+");
+      expect(swd.ratingScale(thirtiethPercentile)).toBe("C");
+      expect(swd.ratingScale(twentiethPercentile)).toBe("B");
       expect(swd.ratingScale(0.9)).toBe("F");
     });
   });

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -113,4 +113,21 @@ describe("sustainable web design model", () => {
       });
     });
   });
+
+  describe("SWD Rating Scale", () => {
+    it("should return a string", () => {
+      expect(typeof swd.ratingScale(averageWebsiteInBytes)).toBe("string");
+    });
+
+    it("should return a rating", () => {
+      // Check a 3MB file size
+      expect(swd.ratingScale(3000000)).toBe("F");
+    });
+
+    it("returns ratings as expected", () => {
+      expect(swd.ratingScale(1000)).toBe("A+");
+      expect(swd.ratingScale(1000000)).toBe("C");
+      expect(swd.ratingScale(10000000)).toBe("F");
+    });
+  });
 });

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -125,9 +125,10 @@ describe("sustainable web design model", () => {
     });
 
     it("returns ratings as expected", () => {
-      expect(swd.ratingScale(1000)).toBe("A+");
-      expect(swd.ratingScale(1000000)).toBe("C");
-      expect(swd.ratingScale(10000000)).toBe("F");
+      expect(swd.ratingScale(0.065)).toBe("A+");
+      expect(swd.ratingScale(0.342)).toBe("C");
+      expect(swd.ratingScale(0.341)).toBe("B");
+      expect(swd.ratingScale(0.9)).toBe("F");
     });
   });
 });

--- a/src/sustainable-web-design.test.js
+++ b/src/sustainable-web-design.test.js
@@ -136,8 +136,11 @@ describe("sustainable web design model", () => {
 
     it("returns ratings as expected", () => {
       expect(swd.ratingScale(fifthPercentile)).toBe("A+");
-      expect(swd.ratingScale(thirtiethPercentile)).toBe("C");
+      expect(swd.ratingScale(tenthPercentile)).toBe("A");
       expect(swd.ratingScale(twentiethPercentile)).toBe("B");
+      expect(swd.ratingScale(thirtiethPercentile)).toBe("C");
+      expect(swd.ratingScale(fortiethPercentile)).toBe("D");
+      expect(swd.ratingScale(fiftiethPercentile)).toBe("E");
       expect(swd.ratingScale(0.9)).toBe("F");
     });
   });


### PR DESCRIPTION
## Triage

### Type of change

Please select any of the below items that are appropriate.

This pull request:

- [ ] Adds a new carbon estimation model to CO2.js
- [x] Adds new functionality to an existing model
- [ ] Fixes a bug with an existing model implementation
- [ ] Add other new functionality to CO2.js
- [ ] Add new data to CO2.js
- [ ] Improves developer experience for contributors
- [ ] Adds contributors to CO2.js
- [ ] Does something not specified above

### Related issue/s

Please list below any issues this pull request is related to.

- #205 

### Docs changes required

Do any changes made in this pull request require parts of the [CO2.js documentation](https://developers.thegreenwebfoundation.org/co2js/overview/) to be updated?

- [x] Yes
- [ ] No
- [ ] I don't know

If you answered "Yes", please create an corresponding issue in our [Developer Documentation repository](https://github.com/thegreenwebfoundation/developer-docs).

Related issue: https://github.com/thegreenwebfoundation/developer-docs/issues/50

## Describe the changes made in this pull request

_As clearly as possible, describe the changes made in the pull request. You should at least detail "what changes have been made" and "what the results of these changes will be"._

This change adds the [Sustainable Web Design rating scale](https://sustainablewebdesign.org/digital-carbon-ratings/) into CO2.js for developers using the Sustainable Web Design Model to estimate emissions.

The rating scale is "off" by default, but developers can opt-in to returning results with a carbon emissions total & a corresponding rating by setting `rating: true` when instantiating an instance of the Sustainable Web Design Model in CO2.js.

```js
import { co2 } from '@tgwf/co2';

const model = new co2({ rating: true });
```

The rating system is based on the ~~number of bytes passed into~~ carbon emissions results calculated by the `perByte`, `perVisit`, `perByteTrace`, or `perVisitTrace` functions. 

Currently the `perByte` and `perVisit` functions return a number representing the estimated CO2e calculated by those functions. When `rating: true` is set, these functions will now return an object with two keys - `rating` and `total`. For example:

```js
import { co2 } from '@tgwf/co2';

const hasRating = new co2({ rating: true });
const noRating = new co2();

hasRating.perByte(1000);

/* Returns:
{ total: 0.0003936519, rating: 'A+' }
*/

noRating.perByte(1000)
/* Returns: 
0.0003936519
*/
```