### PR TITLE
WIP - Try running vitest instead of jest for co2.js

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -2,29 +2,27 @@ name: Unit tests
 on:
   push:
     branches:
-    - main
-    - ca-v0.10.0
+      - main
   pull_request:
     branches:
-    - main
-    - ca-v0.10.0
+      - main
 permissions:
-    contents: read
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install
-      run: npm ci
-    - name: Verify lint
-      run: npm run lint
-    - name: Run unit tests
-      run: npm test
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install
+        run: npm ci
+      - name: Verify lint
+        run: npm run lint
+      - name: Run unit tests
+        run: npm test

--- a/__mocks__/https.js
+++ b/__mocks__/https.js
@@ -1,6 +1,8 @@
+import { vi } from "vitest";
 import { getApiRequestHeaders } from "../src/helpers/index.js";
-const https = jest.createMockFromModule("https");
 import { Stream } from "stream";
+
+const https = vi.mock("https");
 
 const stream = new Stream();
 
@@ -10,19 +12,19 @@ https.get.mockImplementation((url, options, callback) => {
     stream.emit(
       "data",
       Buffer.from(
-        `{"google.com": {"url":"google.com","hosted_by":"Google Inc.","hosted_by_website":"https://www.google.com","partner":null,"green":true}, "pchome.com": {"url":"pchome.com","green":false} }`
-      )
+        `{"google.com": {"url":"google.com","hosted_by":"Google Inc.","hosted_by_website":"https://www.google.com","partner":null,"green":true}, "pchome.com": {"url":"pchome.com","green":false} }`,
+      ),
     );
   } else {
     stream.emit(
       "data",
       Buffer.from(
-        `{"url":"google.com","hosted_by":"Google Inc.","hosted_by_website":"https://www.google.com","partner":null,"green":true}`
-      )
+        `{"url":"google.com","hosted_by":"Google Inc.","hosted_by_website":"https://www.google.com","partner":null,"green":true}`,
+      ),
     );
   }
 
   stream.emit("end");
 });
 
-module.exports = https;
+export default https;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.16.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@tgwf/url2green": "^0.4.0",
+        "@tgwf/url2green": "^0.4.1",
         "all-contributors-cli": "^6.26.1",
         "esbuild": "^0.14.47",
         "esbuild-jest": "^0.5.0",
@@ -21,7 +21,8 @@
         "jest": "^28.1.0",
         "nock": "^13.2.4",
         "np": "^8.0.4",
-        "prettier": "^2.6.2"
+        "prettier": "^2.6.2",
+        "vitest": "^2.1.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -808,6 +809,397 @@
         "node": ">=0.1.95"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
@@ -1214,10 +1606,11 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.20",
@@ -1299,6 +1692,258 @@
         "node": ">=12"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.4.tgz",
+      "integrity": "sha512-jfUJrFct/hTA0XDM5p/htWKoNNTbDLY0KRwEt6pyOA6k2fmk0WVwl65PdUdJZgzGEHWx+49LilkcSaumQRyNQw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.4.tgz",
+      "integrity": "sha512-j4nrEO6nHU1nZUuCfRKoCcvh7PIywQPUCBa2UsootTHvTHIoIu2BzueInGJhhvQO/2FTRdNYpf63xsgEqH9IhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.4.tgz",
+      "integrity": "sha512-GmU/QgGtBTeraKyldC7cDVVvAJEOr3dFLKneez/n7BvX57UdhOqDsVwzU7UOnYA7AAOt+Xb26lk79PldDHgMIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.4.tgz",
+      "integrity": "sha512-N6oDBiZCBKlwYcsEPXGDE4g9RoxZLK6vT98M8111cW7VsVJFpNEqvJeIPfsCzbf0XEakPslh72X0gnlMi4Ddgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.24.4.tgz",
+      "integrity": "sha512-py5oNShCCjCyjWXCZNrRGRpjWsF0ic8f4ieBNra5buQz0O/U6mMXCpC1LvrHuhJsNPgRt36tSYMidGzZiJF6mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.24.4.tgz",
+      "integrity": "sha512-L7VVVW9FCnTTp4i7KrmHeDsDvjB4++KOBENYtNYAiYl96jeBThFfhP6HVxL74v4SiZEVDH/1ILscR5U9S4ms4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.4.tgz",
+      "integrity": "sha512-10ICosOwYChROdQoQo589N5idQIisxjaFE/PAnX2i0Zr84mY0k9zul1ArH0rnJ/fpgiqfu13TFZR5A5YJLOYZA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.4.tgz",
+      "integrity": "sha512-ySAfWs69LYC7QhRDZNKqNhz2UKN8LDfbKSMAEtoEI0jitwfAG2iZwVqGACJT+kfYvvz3/JgsLlcBP+WWoKCLcw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.4.tgz",
+      "integrity": "sha512-uHYJ0HNOI6pGEeZ/5mgm5arNVTI0nLlmrbdph+pGXpC9tFHFDQmDMOEqkmUObRfosJqpU8RliYoGz06qSdtcjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.4.tgz",
+      "integrity": "sha512-38yiWLemQf7aLHDgTg85fh3hW9stJ0Muk7+s6tIkSUOMmi4Xbv5pH/5Bofnsb6spIwD5FJiR+jg71f0CH5OzoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.4.tgz",
+      "integrity": "sha512-q73XUPnkwt9ZNF2xRS4fvneSuaHw2BXuV5rI4cw0fWYVIWIBeDZX7c7FWhFQPNTnE24172K30I+dViWRVD9TwA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.4.tgz",
+      "integrity": "sha512-Aie/TbmQi6UXokJqDZdmTJuZBCU3QBDA8oTKRGtd4ABi/nHgXICulfg1KI6n9/koDsiDbvHAiQO3YAUNa/7BCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.4.tgz",
+      "integrity": "sha512-P8MPErVO/y8ohWSP9JY7lLQ8+YMHfTI4bAdtCi3pC2hTeqFJco2jYspzOzTUB8hwUWIIu1xwOrJE11nP+0JFAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.4.tgz",
+      "integrity": "sha512-K03TljaaoPK5FOyNMZAAEmhlyO49LaE4qCsr0lYHUKyb6QacTNF9pnfPpXnFlFD3TXuFbFbz7tJ51FujUXkXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.4.tgz",
+      "integrity": "sha512-VJYl4xSl/wqG2D5xTYncVWW+26ICV4wubwN9Gs5NrqhJtayikwCXzPL8GDsLnaLU3WwhQ8W02IinYSFJfyo34Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.4.tgz",
+      "integrity": "sha512-ku2GvtPwQfCqoPFIJCqZ8o7bJcj+Y54cZSr43hHca6jLwAiCbZdBUOrqE6y29QFajNAzzpIOwsckaTFmN6/8TA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.4.tgz",
+      "integrity": "sha512-V3nCe+eTt/W6UYNr/wGvO1fLpHUrnlirlypZfKCT1fG6hWfqhPgQV/K/mRBXBpxc0eKLIF18pIOFVPh0mqHjlg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.4.tgz",
+      "integrity": "sha512-LTw1Dfd0mBIEqUVCxbvTE/LLo+9ZxVC9k99v1v4ahg9Aak6FpqOfNu5kRkeTAn0wphoC4JU7No1/rL+bBCEwhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@samverschueren/stream-to-observable": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
@@ -1377,13 +2022,17 @@
       }
     },
     "node_modules/@tgwf/url2green": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@tgwf/url2green/-/url2green-0.4.0.tgz",
-      "integrity": "sha512-jfNqNdtdw/sVrlf1ahKnJmrYLeQ7hE5MJQnPi3BLswboAT1PGgkROEbuQSX5VhDjgyPLwEfplDd5CcamFkZRjg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tgwf/url2green/-/url2green-0.4.1.tgz",
+      "integrity": "sha512-69L+SypBOEz6kWzjboUSd/qxn79ZHTnIvXIqYnF5se52paKlW/397dq1cA3KqegNWirQJ08z5EIP+lKBkLb8jQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "better-sqlite3": "^7.4.5",
+        "better-sqlite3": "^11.0.0",
         "debug": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -1438,6 +2087,13 @@
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -1500,10 +2156,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
-      "dev": true
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.8"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -1665,6 +2325,119 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.4.tgz",
+      "integrity": "sha512-DOETT0Oh1avie/D/o2sgMHGrzYUFFo3zqESB2Hn70z6QB1HrS2IQ9z5DfyTqU8sg4Bpu13zZe9V4+UTNQlUeQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.4",
+        "@vitest/utils": "2.1.4",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.4.tgz",
+      "integrity": "sha512-Ky/O1Lc0QBbutJdW0rqLeFNbuLEyS+mIPiNdlVlp2/yhJ0SbyYqObS5IHdhferJud8MbbwMnexg4jordE5cCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.4.tgz",
+      "integrity": "sha512-L95zIAkEuTDbUX1IsjRl+vyBSLh3PwLLgKpghl37aCK9Jvw0iP+wKwIFhfjdUtA2myLgjrG6VU6JCFLv8q/3Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.4.tgz",
+      "integrity": "sha512-sKRautINI9XICAMl2bjxQM8VfCMTB0EbsBc/EDFA57V6UQevEKY/TOPOF5nzcvCALltiLfXWbq4MaAwWx/YxIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.4",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.4.tgz",
+      "integrity": "sha512-3Kab14fn/5QZRog5BPj6Rs8dc4B+mim27XaKWFWHWA87R56AKjHTGcBFKpvZKDzC4u5Wd0w/qKsUIio3KzWW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.4",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.4.tgz",
+      "integrity": "sha512-4JOxa+UAizJgpZfaCPKK2smq9d8mmjZVPMt2kOsg/R8QkoRzydHH1qHxIYNvr1zlEaFj4SXiaaJWxq/LPLKaLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.4.tgz",
+      "integrity": "sha512-MXDnZn0Awl2S86PSNIim5PWXgIAx8CIkzu35mBdSApUip6RFOGXBCf3YFyeEu8n1IHk4bWD46DeYFu9mQlFIRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.4",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -1923,22 +2696,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-      "dev": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1997,6 +2754,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/assign-symbols": {
@@ -2183,14 +2950,15 @@
       ]
     },
     "node_modules/better-sqlite3": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.5.1.tgz",
-      "integrity": "sha512-+i6tH1y9KEIol1iYpZJrqDwBDQZGHioDENU49Rnidorp3bSXvw/QTYDjQGq9+TFF7RX4q0YV1sEOIRq4vDZdRg==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.5.0.tgz",
+      "integrity": "sha512-e/6eggfOutzoK0JWiU36jsisdWoHOfN9iWiW/SieKvb7SAa6aGNmBM/UKyp+/wWSXpLlWNN8tCPwoDNPhzUvuQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
-        "prebuild-install": "^7.0.0"
+        "prebuild-install": "^7.1.1"
       }
     },
     "node_modules/big-integer": {
@@ -2216,6 +2984,7 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -2229,20 +2998,6 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/boxen": {
@@ -2505,6 +3260,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -2668,6 +3433,23 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/chai": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
+      "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2698,6 +3480,16 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
@@ -2742,7 +3534,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "3.3.0",
@@ -3178,12 +3971,6 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
-    },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -3201,12 +3988,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
     },
     "node_modules/cosmiconfig": {
       "version": "8.2.0",
@@ -3274,12 +4055,13 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -3373,6 +4155,16 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -3657,17 +4449,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
-    },
     "node_modules/detect-libc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -4646,6 +5433,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4847,6 +5644,7 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "dev": true,
+      "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
       }
@@ -4865,6 +5663,16 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
+      "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend-shallow": {
@@ -5056,7 +5864,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -5136,7 +5945,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -5145,11 +5955,12 @@
       "dev": true
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -5169,69 +5980,6 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
-    },
-    "node_modules/gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
-      "dependencies": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/gauge/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gauge/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gauge/node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gauge/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -5298,8 +6046,9 @@
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-      "dev": true
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/github-url-from-git": {
       "version": "1.5.0",
@@ -5515,12 +6264,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true
     },
     "node_modules/has-value": {
       "version": "1.0.0",
@@ -7813,6 +8556,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
+      "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -7832,6 +8582,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.12",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
+      "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/make-dir": {
@@ -8042,19 +8802,40 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
@@ -8082,7 +8863,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -8139,10 +8921,11 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.15.0.tgz",
-      "integrity": "sha512-Ic6z/j6I9RLm4ov7npo1I48UQr2BEyFCqh6p7S1dhEx9jPO0GPGq/e2Rb7x7DroQrmiVMz/Bw1vJm9sPAl2nxA==",
+      "version": "3.71.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.71.0.tgz",
+      "integrity": "sha512-SZ40vRiy/+wRTf21hxkkEjPJZpARzUMVcJoQse2EF8qkUWbbO2z7vd5oA/H6bVH6SZQ5STGcu0KRDS7biNRfxw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -8680,18 +9463,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
-      "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
       }
     },
     "node_modules/number-is-nan": {
@@ -9442,6 +10213,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/pegjs": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
@@ -9455,10 +10243,11 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -9514,11 +10303,41 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.0.tgz",
-      "integrity": "sha512-CNcMgI1xBypOyGqjp3wOc8AAo1nMhZS3Cwd3iHIxOdAUbb+YxdNuM4Z5iIrZ8RLvOsf3F3bl7b7xGq6DjQoNYA==",
+    "node_modules/postcss": {
+      "version": "8.4.47",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.0",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -9527,7 +10346,6 @@
         "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
         "node-abi": "^3.3.0",
-        "npmlog": "^4.0.1",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
         "simple-get": "^4.0.0",
@@ -9603,12 +10421,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -9937,18 +10749,18 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -10214,6 +11026,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.4.tgz",
+      "integrity": "sha512-vGorVWIsWfX3xbcyAS+I047kFKapHYivmkaT63Smj77XwvLSJos6M1xGqZnBPFQFBRZDOcG1QnYEIxAvTr/HjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.6"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.24.4",
+        "@rollup/rollup-android-arm64": "4.24.4",
+        "@rollup/rollup-darwin-arm64": "4.24.4",
+        "@rollup/rollup-darwin-x64": "4.24.4",
+        "@rollup/rollup-freebsd-arm64": "4.24.4",
+        "@rollup/rollup-freebsd-x64": "4.24.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.24.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.24.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.24.4",
+        "@rollup/rollup-linux-arm64-musl": "4.24.4",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.24.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.24.4",
+        "@rollup/rollup-linux-x64-gnu": "4.24.4",
+        "@rollup/rollup-linux-x64-musl": "4.24.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.24.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.24.4",
+        "@rollup/rollup-win32-x64-msvc": "4.24.4",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/rsvp": {
@@ -10704,6 +11554,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -10728,7 +11585,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -10749,6 +11607,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -10985,6 +11844,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -11087,6 +11956,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -11182,6 +12058,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
+      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -11336,6 +12219,7 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -11348,6 +12232,7 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -11357,20 +12242,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/terminal-link": {
@@ -11436,6 +12307,50 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
       "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==",
       "dev": true
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
+      "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.1.tgz",
+      "integrity": "sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/titleize": {
       "version": "3.0.0",
@@ -11569,8 +12484,9 @@
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -11658,6 +12574,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/union-value": {
       "version": "1.0.1",
@@ -11886,6 +12809,193 @@
         "builtins": "^1.0.3"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.10.tgz",
+      "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.4.tgz",
+      "integrity": "sha512-kqa9v+oi4HwkG6g8ufRnb5AeplcRw8jUF6/7/Qz1qRQOXHImG8YnLbB+LLszENwFnoBl9xIf9nVdCFzNd7GQEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.4.tgz",
+      "integrity": "sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.4",
+        "@vitest/mocker": "2.1.4",
+        "@vitest/pretty-format": "^2.1.4",
+        "@vitest/runner": "2.1.4",
+        "@vitest/snapshot": "2.1.4",
+        "@vitest/spy": "2.1.4",
+        "@vitest/utils": "2.1.4",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.7.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.4",
+        "@vitest/ui": "2.1.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -11941,13 +13051,21 @@
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "dev": true
     },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {
@@ -12757,6 +13875,167 @@
         "minimist": "^1.2.0"
       }
     },
+    "@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "dev": true,
+      "optional": true
+    },
     "@eslint/eslintrc": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
@@ -13080,9 +14359,9 @@
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
@@ -13147,6 +14426,132 @@
         "config-chain": "^1.1.11"
       }
     },
+    "@rollup/rollup-android-arm-eabi": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.4.tgz",
+      "integrity": "sha512-jfUJrFct/hTA0XDM5p/htWKoNNTbDLY0KRwEt6pyOA6k2fmk0WVwl65PdUdJZgzGEHWx+49LilkcSaumQRyNQw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-android-arm64": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.4.tgz",
+      "integrity": "sha512-j4nrEO6nHU1nZUuCfRKoCcvh7PIywQPUCBa2UsootTHvTHIoIu2BzueInGJhhvQO/2FTRdNYpf63xsgEqH9IhA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-darwin-arm64": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.4.tgz",
+      "integrity": "sha512-GmU/QgGtBTeraKyldC7cDVVvAJEOr3dFLKneez/n7BvX57UdhOqDsVwzU7UOnYA7AAOt+Xb26lk79PldDHgMIQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-darwin-x64": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.4.tgz",
+      "integrity": "sha512-N6oDBiZCBKlwYcsEPXGDE4g9RoxZLK6vT98M8111cW7VsVJFpNEqvJeIPfsCzbf0XEakPslh72X0gnlMi4Ddgg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-freebsd-arm64": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.24.4.tgz",
+      "integrity": "sha512-py5oNShCCjCyjWXCZNrRGRpjWsF0ic8f4ieBNra5buQz0O/U6mMXCpC1LvrHuhJsNPgRt36tSYMidGzZiJF6mw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-freebsd-x64": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.24.4.tgz",
+      "integrity": "sha512-L7VVVW9FCnTTp4i7KrmHeDsDvjB4++KOBENYtNYAiYl96jeBThFfhP6HVxL74v4SiZEVDH/1ILscR5U9S4ms4g==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.4.tgz",
+      "integrity": "sha512-10ICosOwYChROdQoQo589N5idQIisxjaFE/PAnX2i0Zr84mY0k9zul1ArH0rnJ/fpgiqfu13TFZR5A5YJLOYZA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.4.tgz",
+      "integrity": "sha512-ySAfWs69LYC7QhRDZNKqNhz2UKN8LDfbKSMAEtoEI0jitwfAG2iZwVqGACJT+kfYvvz3/JgsLlcBP+WWoKCLcw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.4.tgz",
+      "integrity": "sha512-uHYJ0HNOI6pGEeZ/5mgm5arNVTI0nLlmrbdph+pGXpC9tFHFDQmDMOEqkmUObRfosJqpU8RliYoGz06qSdtcjg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-musl": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.4.tgz",
+      "integrity": "sha512-38yiWLemQf7aLHDgTg85fh3hW9stJ0Muk7+s6tIkSUOMmi4Xbv5pH/5Bofnsb6spIwD5FJiR+jg71f0CH5OzoA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.4.tgz",
+      "integrity": "sha512-q73XUPnkwt9ZNF2xRS4fvneSuaHw2BXuV5rI4cw0fWYVIWIBeDZX7c7FWhFQPNTnE24172K30I+dViWRVD9TwA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.4.tgz",
+      "integrity": "sha512-Aie/TbmQi6UXokJqDZdmTJuZBCU3QBDA8oTKRGtd4ABi/nHgXICulfg1KI6n9/koDsiDbvHAiQO3YAUNa/7BCw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.4.tgz",
+      "integrity": "sha512-P8MPErVO/y8ohWSP9JY7lLQ8+YMHfTI4bAdtCi3pC2hTeqFJco2jYspzOzTUB8hwUWIIu1xwOrJE11nP+0JFAQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-gnu": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.4.tgz",
+      "integrity": "sha512-K03TljaaoPK5FOyNMZAAEmhlyO49LaE4qCsr0lYHUKyb6QacTNF9pnfPpXnFlFD3TXuFbFbz7tJ51FujUXkXYA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-musl": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.4.tgz",
+      "integrity": "sha512-VJYl4xSl/wqG2D5xTYncVWW+26ICV4wubwN9Gs5NrqhJtayikwCXzPL8GDsLnaLU3WwhQ8W02IinYSFJfyo34Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.4.tgz",
+      "integrity": "sha512-ku2GvtPwQfCqoPFIJCqZ8o7bJcj+Y54cZSr43hHca6jLwAiCbZdBUOrqE6y29QFajNAzzpIOwsckaTFmN6/8TA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.4.tgz",
+      "integrity": "sha512-V3nCe+eTt/W6UYNr/wGvO1fLpHUrnlirlypZfKCT1fG6hWfqhPgQV/K/mRBXBpxc0eKLIF18pIOFVPh0mqHjlg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-x64-msvc": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.4.tgz",
+      "integrity": "sha512-LTw1Dfd0mBIEqUVCxbvTE/LLo+9ZxVC9k99v1v4ahg9Aak6FpqOfNu5kRkeTAn0wphoC4JU7No1/rL+bBCEwhg==",
+      "dev": true,
+      "optional": true
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
@@ -13204,12 +14609,12 @@
       }
     },
     "@tgwf/url2green": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@tgwf/url2green/-/url2green-0.4.0.tgz",
-      "integrity": "sha512-jfNqNdtdw/sVrlf1ahKnJmrYLeQ7hE5MJQnPi3BLswboAT1PGgkROEbuQSX5VhDjgyPLwEfplDd5CcamFkZRjg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tgwf/url2green/-/url2green-0.4.1.tgz",
+      "integrity": "sha512-69L+SypBOEz6kWzjboUSd/qxn79ZHTnIvXIqYnF5se52paKlW/397dq1cA3KqegNWirQJ08z5EIP+lKBkLb8jQ==",
       "dev": true,
       "requires": {
-        "better-sqlite3": "^7.4.5",
+        "better-sqlite3": "^11.0.0",
         "debug": "^4.1.1"
       }
     },
@@ -13265,6 +14670,12 @@
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
       }
+    },
+    "@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -13327,10 +14738,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
-      "dev": true
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.19.8"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -13445,6 +14859,79 @@
       "requires": {
         "@typescript-eslint/types": "5.22.0",
         "eslint-visitor-keys": "^3.0.0"
+      }
+    },
+    "@vitest/expect": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.4.tgz",
+      "integrity": "sha512-DOETT0Oh1avie/D/o2sgMHGrzYUFFo3zqESB2Hn70z6QB1HrS2IQ9z5DfyTqU8sg4Bpu13zZe9V4+UTNQlUeQA==",
+      "dev": true,
+      "requires": {
+        "@vitest/spy": "2.1.4",
+        "@vitest/utils": "2.1.4",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      }
+    },
+    "@vitest/mocker": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.4.tgz",
+      "integrity": "sha512-Ky/O1Lc0QBbutJdW0rqLeFNbuLEyS+mIPiNdlVlp2/yhJ0SbyYqObS5IHdhferJud8MbbwMnexg4jordE5cCoQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/spy": "2.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      }
+    },
+    "@vitest/pretty-format": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.4.tgz",
+      "integrity": "sha512-L95zIAkEuTDbUX1IsjRl+vyBSLh3PwLLgKpghl37aCK9Jvw0iP+wKwIFhfjdUtA2myLgjrG6VU6JCFLv8q/3Ww==",
+      "dev": true,
+      "requires": {
+        "tinyrainbow": "^1.2.0"
+      }
+    },
+    "@vitest/runner": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.4.tgz",
+      "integrity": "sha512-sKRautINI9XICAMl2bjxQM8VfCMTB0EbsBc/EDFA57V6UQevEKY/TOPOF5nzcvCALltiLfXWbq4MaAwWx/YxIA==",
+      "dev": true,
+      "requires": {
+        "@vitest/utils": "2.1.4",
+        "pathe": "^1.1.2"
+      }
+    },
+    "@vitest/snapshot": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.4.tgz",
+      "integrity": "sha512-3Kab14fn/5QZRog5BPj6Rs8dc4B+mim27XaKWFWHWA87R56AKjHTGcBFKpvZKDzC4u5Wd0w/qKsUIio3KzWW4Q==",
+      "dev": true,
+      "requires": {
+        "@vitest/pretty-format": "2.1.4",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      }
+    },
+    "@vitest/spy": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.4.tgz",
+      "integrity": "sha512-4JOxa+UAizJgpZfaCPKK2smq9d8mmjZVPMt2kOsg/R8QkoRzydHH1qHxIYNvr1zlEaFj4SXiaaJWxq/LPLKaLg==",
+      "dev": true,
+      "requires": {
+        "tinyspy": "^3.0.2"
+      }
+    },
+    "@vitest/utils": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.4.tgz",
+      "integrity": "sha512-MXDnZn0Awl2S86PSNIim5PWXgIAx8CIkzu35mBdSApUip6RFOGXBCf3YFyeEu8n1IHk4bWD46DeYFu9mQlFIRg==",
+      "dev": true,
+      "requires": {
+        "@vitest/pretty-format": "2.1.4",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
       }
     },
     "acorn": {
@@ -13638,22 +15125,6 @@
         "picomatch": "^2.0.4"
       }
     },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-      "dev": true,
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -13694,6 +15165,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true
     },
     "assign-symbols": {
@@ -13832,13 +15309,13 @@
       "dev": true
     },
     "better-sqlite3": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.5.1.tgz",
-      "integrity": "sha512-+i6tH1y9KEIol1iYpZJrqDwBDQZGHioDENU49Rnidorp3bSXvw/QTYDjQGq9+TFF7RX4q0YV1sEOIRq4vDZdRg==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.5.0.tgz",
+      "integrity": "sha512-e/6eggfOutzoK0JWiU36jsisdWoHOfN9iWiW/SieKvb7SAa6aGNmBM/UKyp+/wWSXpLlWNN8tCPwoDNPhzUvuQ==",
       "dev": true,
       "requires": {
         "bindings": "^1.5.0",
-        "prebuild-install": "^7.0.0"
+        "prebuild-install": "^7.1.1"
       }
     },
     "big-integer": {
@@ -13871,19 +15348,6 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "boxen": {
@@ -14052,6 +15516,12 @@
         "run-applescript": "^5.0.0"
       }
     },
+    "cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true
+    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -14164,6 +15634,19 @@
         "rsvp": "^4.8.4"
       }
     },
+    "chai": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
+      "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      }
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -14184,6 +15667,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "dev": true
     },
     "chokidar": {
@@ -14558,12 +16047,6 @@
         }
       }
     },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
-    },
     "convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -14577,12 +16060,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
-      "dev": true
-    },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "cosmiconfig": {
@@ -14632,12 +16109,12 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       }
     },
     "decamelize": {
@@ -14693,6 +16170,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true
     },
     "deep-extend": {
@@ -14880,16 +16363,10 @@
         }
       }
     },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
-    },
     "detect-libc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
       "dev": true
     },
     "detect-newline": {
@@ -15514,6 +16991,15 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -15686,6 +17172,12 @@
         "jest-message-util": "^28.1.0",
         "jest-util": "^28.1.0"
       }
+    },
+    "expect-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
+      "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -15917,9 +17409,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "optional": true
     },
@@ -15934,59 +17426,6 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
-      }
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -16032,7 +17471,7 @@
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "dev": true
     },
     "github-url-from-git": {
@@ -16192,12 +17631,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-value": {
@@ -17926,6 +19359,12 @@
         }
       }
     },
+    "loupe": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
+      "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+      "dev": true
+    },
     "lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -17939,6 +19378,15 @@
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.30.12",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
+      "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "make-dir": {
@@ -18099,15 +19547,21 @@
       "dev": true
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true
     },
     "nanomatch": {
@@ -18177,9 +19631,9 @@
       }
     },
     "node-abi": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.15.0.tgz",
-      "integrity": "sha512-Ic6z/j6I9RLm4ov7npo1I48UQr2BEyFCqh6p7S1dhEx9jPO0GPGq/e2Rb7x7DroQrmiVMz/Bw1vJm9sPAl2nxA==",
+      "version": "3.71.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.71.0.tgz",
+      "integrity": "sha512-SZ40vRiy/+wRTf21hxkkEjPJZpARzUMVcJoQse2EF8qkUWbbO2z7vd5oA/H6bVH6SZQ5STGcu0KRDS7biNRfxw==",
       "dev": true,
       "requires": {
         "semver": "^7.3.5"
@@ -18540,18 +19994,6 @@
       "dev": true,
       "requires": {
         "path-key": "^3.0.0"
-      }
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -19074,6 +20516,18 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true
+    },
     "pegjs": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
@@ -19081,9 +20535,9 @@
       "dev": true
     },
     "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "picomatch": {
@@ -19119,10 +20573,21 @@
       "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
       "dev": true
     },
+    "postcss": {
+      "version": "8.4.47",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
     "prebuild-install": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.0.tgz",
-      "integrity": "sha512-CNcMgI1xBypOyGqjp3wOc8AAo1nMhZS3Cwd3iHIxOdAUbb+YxdNuM4Z5iIrZ8RLvOsf3F3bl7b7xGq6DjQoNYA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
       "dev": true,
       "requires": {
         "detect-libc": "^2.0.0",
@@ -19132,7 +20597,6 @@
         "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
         "node-abi": "^3.3.0",
-        "npmlog": "^4.0.1",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
         "simple-get": "^4.0.0",
@@ -19180,12 +20644,6 @@
           "dev": true
         }
       }
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -19415,18 +20873,14 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "readdirp": {
@@ -19616,6 +21070,34 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.4.tgz",
+      "integrity": "sha512-vGorVWIsWfX3xbcyAS+I047kFKapHYivmkaT63Smj77XwvLSJos6M1xGqZnBPFQFBRZDOcG1QnYEIxAvTr/HjA==",
+      "dev": true,
+      "requires": {
+        "@rollup/rollup-android-arm-eabi": "4.24.4",
+        "@rollup/rollup-android-arm64": "4.24.4",
+        "@rollup/rollup-darwin-arm64": "4.24.4",
+        "@rollup/rollup-darwin-x64": "4.24.4",
+        "@rollup/rollup-freebsd-arm64": "4.24.4",
+        "@rollup/rollup-freebsd-x64": "4.24.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.24.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.24.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.24.4",
+        "@rollup/rollup-linux-arm64-musl": "4.24.4",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.24.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.24.4",
+        "@rollup/rollup-linux-x64-gnu": "4.24.4",
+        "@rollup/rollup-linux-x64-musl": "4.24.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.24.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.24.4",
+        "@rollup/rollup-win32-x64-msvc": "4.24.4",
+        "@types/estree": "1.0.6",
+        "fsevents": "~2.3.2"
       }
     },
     "rsvp": {
@@ -19987,6 +21469,12 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -20196,6 +21684,12 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
+    "source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true
+    },
     "source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -20289,6 +21783,12 @@
         }
       }
     },
+    "stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -20366,6 +21866,12 @@
           "dev": true
         }
       }
+    },
+    "std-env": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
+      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
+      "dev": true
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -20493,19 +21999,6 @@
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "terminal-link": {
@@ -20561,6 +22054,36 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
       "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==",
+      "dev": true
+    },
+    "tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "tinyexec": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
+      "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==",
+      "dev": true
+    },
+    "tinypool": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.1.tgz",
+      "integrity": "sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==",
+      "dev": true
+    },
+    "tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true
+    },
+    "tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
       "dev": true
     },
     "titleize": {
@@ -20661,7 +22184,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -20728,6 +22251,12 @@
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.1",
@@ -20912,6 +22441,91 @@
         "builtins": "^1.0.3"
       }
     },
+    "vite": {
+      "version": "5.4.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.10.tgz",
+      "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
+      "dev": true,
+      "requires": {
+        "esbuild": "^0.21.3",
+        "fsevents": "~2.3.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "dependencies": {
+        "esbuild": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+          "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+          "dev": true,
+          "requires": {
+            "@esbuild/aix-ppc64": "0.21.5",
+            "@esbuild/android-arm": "0.21.5",
+            "@esbuild/android-arm64": "0.21.5",
+            "@esbuild/android-x64": "0.21.5",
+            "@esbuild/darwin-arm64": "0.21.5",
+            "@esbuild/darwin-x64": "0.21.5",
+            "@esbuild/freebsd-arm64": "0.21.5",
+            "@esbuild/freebsd-x64": "0.21.5",
+            "@esbuild/linux-arm": "0.21.5",
+            "@esbuild/linux-arm64": "0.21.5",
+            "@esbuild/linux-ia32": "0.21.5",
+            "@esbuild/linux-loong64": "0.21.5",
+            "@esbuild/linux-mips64el": "0.21.5",
+            "@esbuild/linux-ppc64": "0.21.5",
+            "@esbuild/linux-riscv64": "0.21.5",
+            "@esbuild/linux-s390x": "0.21.5",
+            "@esbuild/linux-x64": "0.21.5",
+            "@esbuild/netbsd-x64": "0.21.5",
+            "@esbuild/openbsd-x64": "0.21.5",
+            "@esbuild/sunos-x64": "0.21.5",
+            "@esbuild/win32-arm64": "0.21.5",
+            "@esbuild/win32-ia32": "0.21.5",
+            "@esbuild/win32-x64": "0.21.5"
+          }
+        }
+      }
+    },
+    "vite-node": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.4.tgz",
+      "integrity": "sha512-kqa9v+oi4HwkG6g8ufRnb5AeplcRw8jUF6/7/Qz1qRQOXHImG8YnLbB+LLszENwFnoBl9xIf9nVdCFzNd7GQEg==",
+      "dev": true,
+      "requires": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      }
+    },
+    "vitest": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.4.tgz",
+      "integrity": "sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/expect": "2.1.4",
+        "@vitest/mocker": "2.1.4",
+        "@vitest/pretty-format": "^2.1.4",
+        "@vitest/runner": "2.1.4",
+        "@vitest/snapshot": "2.1.4",
+        "@vitest/spy": "2.1.4",
+        "@vitest/utils": "2.1.4",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.7.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.4",
+        "why-is-node-running": "^2.3.0"
+      }
+    },
     "walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -20961,13 +22575,14 @@
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "dev": true
     },
-    "wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+    "why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
       }
     },
     "widest-line": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     }
   },
   "scripts": {
-    "test": "jest src",
-    "test:watch": "jest --watch src",
+    "test": "vitest run src",
+    "test:watch": "vitest src",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "serve": "python -m http.server --directory ./public",
@@ -44,7 +44,7 @@
   "author": "Chris Adams",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@tgwf/url2green": "^0.4.0",
+    "@tgwf/url2green": "^0.4.1",
     "all-contributors-cli": "^6.26.1",
     "esbuild": "^0.14.47",
     "esbuild-jest": "^0.5.0",
@@ -56,7 +56,8 @@
     "jest": "^28.1.0",
     "nock": "^13.2.4",
     "np": "^8.0.4",
-    "prettier": "^2.6.2"
+    "prettier": "^2.6.2",
+    "vitest": "^2.1.4"
   },
   "jest": {
     "transform": {

--- a/src/1byte.test.js
+++ b/src/1byte.test.js
@@ -27,7 +27,7 @@ describe("OneByte", () => {
 
       expect(instance.perByte(MILLION, true)).toBeCloseTo(
         ONEBYTE.MILLION_GREEN,
-        5,
+        5
       );
     });
   });

--- a/src/1byte.test.js
+++ b/src/1byte.test.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import { describe, expect, it } from "vitest";
+
 import { MILLION, ONEBYTE } from "./constants/test-constants.js";
 
 import OneByte from "./1byte.js";
@@ -25,7 +27,7 @@ describe("OneByte", () => {
 
       expect(instance.perByte(MILLION, true)).toBeCloseTo(
         ONEBYTE.MILLION_GREEN,
-        5
+        5,
       );
     });
   });

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import { beforeEach, describe, expect, it } from "vitest";
+
 import { MILLION, SWDV3 } from "./constants/test-constants.js";
 
 import CO2 from "./co2.js";
@@ -29,19 +31,19 @@ describe("co2", () => {
         co2.perVisit(MILLION);
         expect(parseFloat(co2.perVisit(MILLION).toFixed(5))).toBeCloseTo(
           parseFloat(MILLION_PERVISIT_GREY.toFixed(5)),
-          3
+          3,
         );
       });
 
       it("returns a lower CO2 number for data transfer from domains using entirely 'green' power", () => {
         expect(parseFloat(co2.perVisit(MILLION, false).toFixed(5))).toBeCloseTo(
           parseFloat(MILLION_PERVISIT_GREY.toFixed(5)),
-          3
+          3,
         );
 
         expect(parseFloat(co2.perVisit(MILLION, true).toFixed(5))).toBeCloseTo(
           parseFloat(MILLION_PERVISIT_GREEN.toFixed(5)),
-          3
+          3,
         );
       });
     });
@@ -71,46 +73,46 @@ describe("co2", () => {
           co2 = new CO2({ results: "segment" });
           const res = co2.perVisit(MILLION);
           expect(
-            parseFloat(res["consumerDeviceCO2 - first"].toFixed(5))
+            parseFloat(res["consumerDeviceCO2 - first"].toFixed(5)),
           ).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_DEVICES_FIRST.toFixed(5))
+            parseFloat(MILLION_PERVISIT_GREY_DEVICES_FIRST.toFixed(5)),
           );
           expect(parseFloat(res["networkCO2 - first"].toFixed(5))).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_NETWORKS_FIRST.toFixed(5))
+            parseFloat(MILLION_PERVISIT_GREY_NETWORKS_FIRST.toFixed(5)),
           );
           expect(
-            parseFloat(res["dataCenterCO2 - first"].toFixed(5))
+            parseFloat(res["dataCenterCO2 - first"].toFixed(5)),
           ).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_DATACENTERS_FIRST.toFixed(5))
+            parseFloat(MILLION_PERVISIT_GREY_DATACENTERS_FIRST.toFixed(5)),
           );
           expect(
-            parseFloat(res["productionCO2 - first"].toFixed(5))
+            parseFloat(res["productionCO2 - first"].toFixed(5)),
           ).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_PRODUCTION_FIRST.toFixed(5))
+            parseFloat(MILLION_PERVISIT_GREY_PRODUCTION_FIRST.toFixed(5)),
           );
           expect(
-            parseFloat(res["consumerDeviceCO2 - subsequent"].toFixed(5))
+            parseFloat(res["consumerDeviceCO2 - subsequent"].toFixed(5)),
           ).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_DEVICES_SECOND.toFixed(5))
+            parseFloat(MILLION_PERVISIT_GREY_DEVICES_SECOND.toFixed(5)),
           );
           expect(
-            parseFloat(res["networkCO2 - subsequent"].toFixed(5))
+            parseFloat(res["networkCO2 - subsequent"].toFixed(5)),
           ).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_NETWORKS_SECOND.toFixed(5))
+            parseFloat(MILLION_PERVISIT_GREY_NETWORKS_SECOND.toFixed(5)),
           );
           expect(
-            parseFloat(res["dataCenterCO2 - subsequent"].toFixed(5))
+            parseFloat(res["dataCenterCO2 - subsequent"].toFixed(5)),
           ).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_DATACENTERS_SECOND.toFixed(5))
+            parseFloat(MILLION_PERVISIT_GREY_DATACENTERS_SECOND.toFixed(5)),
           );
           expect(
-            parseFloat(res["productionCO2 - subsequent"].toFixed(5))
+            parseFloat(res["productionCO2 - subsequent"].toFixed(5)),
           ).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_PRODUCTION_SECOND.toFixed(5))
+            parseFloat(MILLION_PERVISIT_GREY_PRODUCTION_SECOND.toFixed(5)),
           );
           expect(parseFloat(res.total.toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_PERVISIT_GREY.toFixed(5)),
-            3
+            3,
           );
         });
         it("returns adjusted data center and total emissions for when green, other values remain the same as grey", () => {
@@ -119,35 +121,35 @@ describe("co2", () => {
           // Since the data center emissions are the only ones that change, we can just check those
           // and the total. To check the rest stay the same as grey, we can just check the device results.
           expect(
-            parseFloat(res["consumerDeviceCO2 - first"].toFixed(5))
+            parseFloat(res["consumerDeviceCO2 - first"].toFixed(5)),
           ).toBeCloseTo(
             parseFloat(MILLION_PERVISIT_GREY_DEVICES_FIRST.toFixed(5)),
-            3
+            3,
           );
 
           expect(
-            parseFloat(res["dataCenterCO2 - first"].toFixed(5))
+            parseFloat(res["dataCenterCO2 - first"].toFixed(5)),
           ).toBeCloseTo(
             parseFloat(MILLION_PERVISIT_GREEN_DATACENTERS_FIRST.toFixed(5)),
-            3
+            3,
           );
 
           expect(
-            parseFloat(res["consumerDeviceCO2 - subsequent"].toFixed(5))
+            parseFloat(res["consumerDeviceCO2 - subsequent"].toFixed(5)),
           ).toBeCloseTo(
             parseFloat(MILLION_PERVISIT_GREY_DEVICES_SECOND.toFixed(5)),
-            3
+            3,
           );
           expect(
-            parseFloat(res["dataCenterCO2 - subsequent"].toFixed(5))
+            parseFloat(res["dataCenterCO2 - subsequent"].toFixed(5)),
           ).toBeCloseTo(
             parseFloat(MILLION_PERVISIT_GREEN_DATACENTERS_SECOND.toFixed(5)),
-            3
+            3,
           );
 
           expect(parseFloat(res.total.toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_PERVISIT_GREEN.toFixed(5)),
-            3
+            3,
           );
         });
       });
@@ -157,15 +159,15 @@ describe("co2", () => {
           const res = co2.perByte(MILLION, true);
           expect(parseFloat(res["consumerDeviceCO2"].toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREY_DEVICES.toFixed(5)),
-            3
+            3,
           );
           expect(parseFloat(res["dataCenterCO2"].toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREEN_DATACENTERS.toFixed(5)),
-            3
+            3,
           );
           expect(parseFloat(res.total.toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREEN.toFixed(5)),
-            3
+            3,
           );
         });
         it("returns an object with devices, networks, data centers, and production emissions shown separately, as well as the total emissions", () => {
@@ -173,23 +175,23 @@ describe("co2", () => {
           const res = co2.perByte(MILLION);
           expect(parseFloat(res["consumerDeviceCO2"].toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREY_DEVICES.toFixed(5)),
-            3
+            3,
           );
           expect(parseFloat(res["networkCO2"].toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREY_NETWORKS.toFixed(5)),
-            3
+            3,
           );
           expect(parseFloat(res["dataCenterCO2"].toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREY_DATACENTERS.toFixed(5)),
-            3
+            3,
           );
           expect(parseFloat(res["productionCO2"].toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREY_PRODUCTION.toFixed(5)),
-            3
+            3,
           );
           expect(parseFloat(res.total.toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREY.toFixed(5)),
-            3
+            3,
           );
         });
       });
@@ -200,7 +202,7 @@ describe("co2", () => {
     // Test for error if incorrect model is passed
     it("throws an error if model is not valid", () => {
       expect(() => (co2 = new CO2({ model: "1direction" }))).toThrowError(
-        `"1direction" is not a valid model. Please use "1byte" for the OneByte model, and "swd" for the Sustainable Web Design model.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`
+        `"1direction" is not a valid model. Please use "1byte" for the OneByte model, and "swd" for the Sustainable Web Design model.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`,
       );
     });
 
@@ -210,7 +212,7 @@ describe("co2", () => {
         co2 = new CO2({ model: "1byte" });
         co2.perVisit(10);
       }).toThrowError(
-        `The perVisit() method is not supported in the model you are using. Try using perByte() instead.\nSee https://developers.thegreenwebfoundation.org/co2js/methods/ to learn more about the methods available in CO2.js.`
+        `The perVisit() method is not supported in the model you are using. Try using perByte() instead.\nSee https://developers.thegreenwebfoundation.org/co2js/methods/ to learn more about the methods available in CO2.js.`,
       );
     });
 
@@ -218,7 +220,7 @@ describe("co2", () => {
       expect(() => {
         co2 = new CO2({ model: "1byte", rating: true });
       }).toThrowError(
-        `The rating system is not supported in the model you are using. Try using the Sustainable Web Design model instead.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`
+        `The rating system is not supported in the model you are using. Try using the Sustainable Web Design model instead.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`,
       );
     });
 
@@ -226,7 +228,7 @@ describe("co2", () => {
       expect(() => {
         co2 = new CO2({ rating: "false" });
       }).toThrowError(
-        `The rating option must be a boolean. Please use true or false.\nSee https://developers.thegreenwebfoundation.org/co2js/options/ to learn more about the options available in CO2.js.`
+        `The rating option must be a boolean. Please use true or false.\nSee https://developers.thegreenwebfoundation.org/co2js/options/ to learn more about the options available in CO2.js.`,
       );
     });
   });
@@ -251,20 +253,20 @@ describe("co2", () => {
     it("perByteTrace is the same as perByte", () => {
       expect(co2.perByteTrace(MILLION).co2).toBe(co2.perByte(MILLION));
       expect(co2.perByteTrace(MILLION, true).co2).toBe(
-        co2.perByte(MILLION, true)
+        co2.perByte(MILLION, true),
       );
       expect(co2.perByteTrace(MILLION, true, {}).co2).toBe(
-        co2.perByte(MILLION, true)
+        co2.perByte(MILLION, true),
       );
     });
 
     it("perVisitTrace is the same as perVisit", () => {
       expect(co2.perVisitTrace(MILLION).co2).toBe(co2.perVisit(MILLION));
       expect(co2.perVisitTrace(MILLION, true).co2).toBe(
-        co2.perVisit(MILLION, true)
+        co2.perVisit(MILLION, true),
       );
       expect(co2.perVisitTrace(MILLION, true, {}).co2).toBe(
-        co2.perVisit(MILLION, true)
+        co2.perVisit(MILLION, true),
       );
     });
 
@@ -273,25 +275,25 @@ describe("co2", () => {
       expect(co2.perByteTrace(MILLION)).toHaveProperty("variables");
       expect(co2.perByteTrace(MILLION)).toHaveProperty("green");
       expect(co2.perByteTrace(MILLION)).toHaveProperty(
-        "variables.gridIntensity"
+        "variables.gridIntensity",
       );
       expect(co2.perByteTrace(MILLION)).not.toHaveProperty(
-        "variables.firstVisitPercentage"
+        "variables.firstVisitPercentage",
       );
       expect(co2.perVisitTrace(MILLION)).toHaveProperty("co2");
       expect(co2.perVisitTrace(MILLION)).toHaveProperty("variables");
       expect(co2.perVisitTrace(MILLION)).toHaveProperty("green");
       expect(co2.perVisitTrace(MILLION)).toHaveProperty(
-        "variables.gridIntensity"
+        "variables.gridIntensity",
       );
       expect(co2.perVisitTrace(MILLION)).toHaveProperty(
-        "variables.firstVisitPercentage"
+        "variables.firstVisitPercentage",
       );
       expect(co2.perVisitTrace(MILLION)).toHaveProperty(
-        "variables.returnVisitPercentage"
+        "variables.returnVisitPercentage",
       );
       expect(co2.perVisitTrace(MILLION)).toHaveProperty(
-        "variables.dataReloadRatio"
+        "variables.dataReloadRatio",
       );
     });
   });
@@ -305,7 +307,7 @@ describe("co2", () => {
             device: 678.87,
             dataCenter: { country: "TWN" },
           },
-        }).co2
+        }).co2,
       ).toBeGreaterThan(0);
 
       expect(
@@ -315,7 +317,7 @@ describe("co2", () => {
             dataCenter: { country: "TWN" },
             network: { country: "TWN" },
           },
-        }).co2
+        }).co2,
       ).toBeGreaterThan(0);
     });
   });
@@ -337,8 +339,8 @@ describe("co2", () => {
                 device: "561",
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(MILLION_PERVISIT_GREY, 3);
 
       expect(
@@ -349,8 +351,8 @@ describe("co2", () => {
                 device: "561",
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(MILLION_GREY, 3);
     });
 
@@ -363,13 +365,13 @@ describe("co2", () => {
                 device: TwnGridIntensityValue,
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(
         parseFloat(
-          MILLION_PERVISIT_GREY_DEVICE_GRID_INTENSITY_CHANGE.toPrecision(5)
+          MILLION_PERVISIT_GREY_DEVICE_GRID_INTENSITY_CHANGE.toPrecision(5),
         ),
-        3
+        3,
       );
 
       expect(
@@ -380,13 +382,13 @@ describe("co2", () => {
                 device: TwnGridIntensityValue,
               },
             })
-            .co2.toPrecision(4)
-        )
+            .co2.toPrecision(4),
+        ),
       ).toBeCloseTo(
         parseFloat(
-          MILLION_PERBYTE_GREY_DEVICE_GRID_INTENSITY_CHANGE.toPrecision(4)
+          MILLION_PERBYTE_GREY_DEVICE_GRID_INTENSITY_CHANGE.toPrecision(4),
         ),
-        3
+        3,
       );
     });
 
@@ -401,8 +403,8 @@ describe("co2", () => {
                 },
               },
             })
-            .co2.toFixed(5)
-        )
+            .co2.toFixed(5),
+        ),
       ).toBeCloseTo(MILLION_PERVISIT_GREY_DEVICE_GRID_INTENSITY_CHANGE, 3);
       expect(
         parseFloat(
@@ -414,8 +416,8 @@ describe("co2", () => {
                 },
               },
             })
-            .co2.toPrecision(4)
-        )
+            .co2.toPrecision(4),
+        ),
       ).toBeCloseTo(MILLION_PERBYTE_GREY_DEVICE_GRID_INTENSITY_CHANGE, 3);
     });
   });
@@ -437,8 +439,8 @@ describe("co2", () => {
                 dataCenter: "565.629",
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(MILLION_PERVISIT_GREY, 3);
       expect(
         parseFloat(
@@ -448,8 +450,8 @@ describe("co2", () => {
                 dataCenter: "565.629",
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(MILLION_GREY, 3);
     });
 
@@ -462,13 +464,13 @@ describe("co2", () => {
                 dataCenter: TwnGridIntensityValue,
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(
         parseFloat(
-          MILLION_PERVISIT_GREY_DATACENTER_GRID_INTENSITY_CHANGE.toPrecision(5)
+          MILLION_PERVISIT_GREY_DATACENTER_GRID_INTENSITY_CHANGE.toPrecision(5),
         ),
-        3
+        3,
       );
       expect(
         parseFloat(
@@ -478,13 +480,13 @@ describe("co2", () => {
                 dataCenter: TwnGridIntensityValue,
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(
         parseFloat(
-          MILLION_PERBYTE_GREY_DATACENTER_GRID_INTENSITY_CHANGE.toPrecision(5)
+          MILLION_PERBYTE_GREY_DATACENTER_GRID_INTENSITY_CHANGE.toPrecision(5),
         ),
-        3
+        3,
       );
     });
 
@@ -499,8 +501,8 @@ describe("co2", () => {
                 },
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(MILLION_PERVISIT_GREY_DATACENTER_GRID_INTENSITY_CHANGE, 3);
       expect(
         parseFloat(
@@ -512,8 +514,8 @@ describe("co2", () => {
                 },
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(MILLION_PERBYTE_GREY_DATACENTER_GRID_INTENSITY_CHANGE, 3);
     });
   });
@@ -535,8 +537,8 @@ describe("co2", () => {
                 network: "561",
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(MILLION_PERVISIT_GREY, 3);
 
       expect(
@@ -547,8 +549,8 @@ describe("co2", () => {
                 network: "561",
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(MILLION_GREY, 3);
     });
 
@@ -561,13 +563,13 @@ describe("co2", () => {
                 network: TwnGridIntensityValue,
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(
         parseFloat(
-          MILLION_PERVISIT_GREY_NETWORK_GRID_INTENSITY_CHANGE.toFixed(5)
+          MILLION_PERVISIT_GREY_NETWORK_GRID_INTENSITY_CHANGE.toFixed(5),
         ),
-        3
+        3,
       );
       expect(
         parseFloat(
@@ -577,13 +579,13 @@ describe("co2", () => {
                 network: TwnGridIntensityValue,
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(
         parseFloat(
-          MILLION_PERBYTE_GREY_NETWORK_GRID_INTENSITY_CHANGE.toPrecision(5)
+          MILLION_PERBYTE_GREY_NETWORK_GRID_INTENSITY_CHANGE.toPrecision(5),
         ),
-        3
+        3,
       );
     });
 
@@ -598,8 +600,8 @@ describe("co2", () => {
                 },
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(MILLION_PERVISIT_GREY_NETWORK_GRID_INTENSITY_CHANGE, 3);
       expect(
         parseFloat(
@@ -611,8 +613,8 @@ describe("co2", () => {
                 },
               },
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(MILLION_PERBYTE_GREY_NETWORK_GRID_INTENSITY_CHANGE, 3);
     });
   });
@@ -624,7 +626,7 @@ describe("co2", () => {
       expect(
         co2.perVisitTrace(1000000, false, {
           dataReloadRatio: 0.5,
-        }).co2
+        }).co2,
       ).toBeGreaterThan(MILLION_PERVISIT_GREY);
     });
 
@@ -633,8 +635,8 @@ describe("co2", () => {
         parseFloat(
           co2
             .perVisitTrace(1000000, false, { dataReloadRatio: "0.5" })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(MILLION_PERVISIT_GREY, 3);
     });
 
@@ -645,8 +647,8 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               dataReloadRatio: 1.5,
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(MILLION_PERVISIT_GREY, 3);
       expect(
         parseFloat(
@@ -654,13 +656,13 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               dataReloadRatio: -1.5,
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(MILLION_PERVISIT_GREY, 3);
       expect(
         co2.perVisitTrace(1000000, false, {
           dataReloadRatio: 0,
-        }).co2
+        }).co2,
       ).toBeLessThan(MILLION_PERVISIT_GREY);
     });
   });
@@ -674,7 +676,7 @@ describe("co2", () => {
         co2.perVisitTrace(MILLION, false, {
           firstVisitPercentage: 0.8,
           returnVisitPercentage: 0.2,
-        }).co2
+        }).co2,
       ).toBeGreaterThan(MILLION_PERVISIT_GREY);
 
       expect(
@@ -684,8 +686,8 @@ describe("co2", () => {
               firstVisitPercentage: 0.8,
               returnVisitPercentage: 0.2,
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBeCloseTo(MILLION_GREY, 3);
     });
 
@@ -696,8 +698,8 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               firstVisitPercentage: "0.8",
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBe(MILLION_PERVISIT_GREY);
     });
     it("expects firstVisitPercentage to be a number between 0 and 1", () => {
@@ -708,8 +710,8 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               firstVisitPercentage: 1.5,
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBe(MILLION_PERVISIT_GREY);
       expect(
         parseFloat(
@@ -717,13 +719,13 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               firstVisitPercentage: -1.5,
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBe(MILLION_PERVISIT_GREY);
       expect(
         co2.perVisitTrace(1000000, false, {
           firstVisitPercentage: 0,
-        }).co2
+        }).co2,
       ).toBeLessThan(MILLION_PERVISIT_GREY);
     });
     it("expects returnVisitPercentage to be a number", () => {
@@ -733,8 +735,8 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               returnVisitPercentage: "0.5",
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBe(MILLION_PERVISIT_GREY);
     });
     it("expects returnVisitPercentage to be a number between 0 and 1", () => {
@@ -744,8 +746,8 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               returnVisitPercentage: 1.5,
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBe(MILLION_PERVISIT_GREY);
       expect(
         parseFloat(
@@ -753,13 +755,13 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               returnVisitPercentage: -1.5,
             })
-            .co2.toPrecision(5)
-        )
+            .co2.toPrecision(5),
+        ),
       ).toBe(MILLION_PERVISIT_GREY);
       expect(
         co2.perVisitTrace(1000000, false, {
           returnVisitPercentage: 0,
-        }).co2
+        }).co2,
       ).toBeLessThan(MILLION_PERVISIT_GREY);
     });
   });
@@ -931,13 +933,13 @@ describe("co2", () => {
       expect(res.variables.greenHostingFactor).toBe(0);
       expect(res.green).toBe(false);
       expect(res.variables.gridIntensity.device.value).toBe(
-        SWDM4_GLOBAL_GRID_INTENSITY
+        SWDM4_GLOBAL_GRID_INTENSITY,
       );
       expect(res.variables.gridIntensity.dataCenter.value).toBe(
-        SWDM4_GLOBAL_GRID_INTENSITY
+        SWDM4_GLOBAL_GRID_INTENSITY,
       );
       expect(res.variables.gridIntensity.network.value).toBe(
-        SWDM4_GLOBAL_GRID_INTENSITY
+        SWDM4_GLOBAL_GRID_INTENSITY,
       );
     });
     it("returns the expected object when adjustments are made", () => {
@@ -992,13 +994,13 @@ describe("co2", () => {
       expect(res.variables.returnVisitPercentage).toBe(0);
       expect(res.variables.dataReloadRatio).toBe(0);
       expect(res.variables.gridIntensity.device.value).toBe(
-        SWDM4_GLOBAL_GRID_INTENSITY
+        SWDM4_GLOBAL_GRID_INTENSITY,
       );
       expect(res.variables.gridIntensity.dataCenter.value).toBe(
-        SWDM4_GLOBAL_GRID_INTENSITY
+        SWDM4_GLOBAL_GRID_INTENSITY,
       );
       expect(res.variables.gridIntensity.network.value).toBe(
-        SWDM4_GLOBAL_GRID_INTENSITY
+        SWDM4_GLOBAL_GRID_INTENSITY,
       );
     });
     it("returns the expected object when adjustments are made", () => {

--- a/src/co2.test.js
+++ b/src/co2.test.js
@@ -31,19 +31,19 @@ describe("co2", () => {
         co2.perVisit(MILLION);
         expect(parseFloat(co2.perVisit(MILLION).toFixed(5))).toBeCloseTo(
           parseFloat(MILLION_PERVISIT_GREY.toFixed(5)),
-          3,
+          3
         );
       });
 
       it("returns a lower CO2 number for data transfer from domains using entirely 'green' power", () => {
         expect(parseFloat(co2.perVisit(MILLION, false).toFixed(5))).toBeCloseTo(
           parseFloat(MILLION_PERVISIT_GREY.toFixed(5)),
-          3,
+          3
         );
 
         expect(parseFloat(co2.perVisit(MILLION, true).toFixed(5))).toBeCloseTo(
           parseFloat(MILLION_PERVISIT_GREEN.toFixed(5)),
-          3,
+          3
         );
       });
     });
@@ -73,46 +73,46 @@ describe("co2", () => {
           co2 = new CO2({ results: "segment" });
           const res = co2.perVisit(MILLION);
           expect(
-            parseFloat(res["consumerDeviceCO2 - first"].toFixed(5)),
+            parseFloat(res["consumerDeviceCO2 - first"].toFixed(5))
           ).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_DEVICES_FIRST.toFixed(5)),
+            parseFloat(MILLION_PERVISIT_GREY_DEVICES_FIRST.toFixed(5))
           );
           expect(parseFloat(res["networkCO2 - first"].toFixed(5))).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_NETWORKS_FIRST.toFixed(5)),
+            parseFloat(MILLION_PERVISIT_GREY_NETWORKS_FIRST.toFixed(5))
           );
           expect(
-            parseFloat(res["dataCenterCO2 - first"].toFixed(5)),
+            parseFloat(res["dataCenterCO2 - first"].toFixed(5))
           ).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_DATACENTERS_FIRST.toFixed(5)),
+            parseFloat(MILLION_PERVISIT_GREY_DATACENTERS_FIRST.toFixed(5))
           );
           expect(
-            parseFloat(res["productionCO2 - first"].toFixed(5)),
+            parseFloat(res["productionCO2 - first"].toFixed(5))
           ).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_PRODUCTION_FIRST.toFixed(5)),
+            parseFloat(MILLION_PERVISIT_GREY_PRODUCTION_FIRST.toFixed(5))
           );
           expect(
-            parseFloat(res["consumerDeviceCO2 - subsequent"].toFixed(5)),
+            parseFloat(res["consumerDeviceCO2 - subsequent"].toFixed(5))
           ).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_DEVICES_SECOND.toFixed(5)),
+            parseFloat(MILLION_PERVISIT_GREY_DEVICES_SECOND.toFixed(5))
           );
           expect(
-            parseFloat(res["networkCO2 - subsequent"].toFixed(5)),
+            parseFloat(res["networkCO2 - subsequent"].toFixed(5))
           ).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_NETWORKS_SECOND.toFixed(5)),
+            parseFloat(MILLION_PERVISIT_GREY_NETWORKS_SECOND.toFixed(5))
           );
           expect(
-            parseFloat(res["dataCenterCO2 - subsequent"].toFixed(5)),
+            parseFloat(res["dataCenterCO2 - subsequent"].toFixed(5))
           ).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_DATACENTERS_SECOND.toFixed(5)),
+            parseFloat(MILLION_PERVISIT_GREY_DATACENTERS_SECOND.toFixed(5))
           );
           expect(
-            parseFloat(res["productionCO2 - subsequent"].toFixed(5)),
+            parseFloat(res["productionCO2 - subsequent"].toFixed(5))
           ).toBeCloseTo(
-            parseFloat(MILLION_PERVISIT_GREY_PRODUCTION_SECOND.toFixed(5)),
+            parseFloat(MILLION_PERVISIT_GREY_PRODUCTION_SECOND.toFixed(5))
           );
           expect(parseFloat(res.total.toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_PERVISIT_GREY.toFixed(5)),
-            3,
+            3
           );
         });
         it("returns adjusted data center and total emissions for when green, other values remain the same as grey", () => {
@@ -121,35 +121,35 @@ describe("co2", () => {
           // Since the data center emissions are the only ones that change, we can just check those
           // and the total. To check the rest stay the same as grey, we can just check the device results.
           expect(
-            parseFloat(res["consumerDeviceCO2 - first"].toFixed(5)),
+            parseFloat(res["consumerDeviceCO2 - first"].toFixed(5))
           ).toBeCloseTo(
             parseFloat(MILLION_PERVISIT_GREY_DEVICES_FIRST.toFixed(5)),
-            3,
+            3
           );
 
           expect(
-            parseFloat(res["dataCenterCO2 - first"].toFixed(5)),
+            parseFloat(res["dataCenterCO2 - first"].toFixed(5))
           ).toBeCloseTo(
             parseFloat(MILLION_PERVISIT_GREEN_DATACENTERS_FIRST.toFixed(5)),
-            3,
+            3
           );
 
           expect(
-            parseFloat(res["consumerDeviceCO2 - subsequent"].toFixed(5)),
+            parseFloat(res["consumerDeviceCO2 - subsequent"].toFixed(5))
           ).toBeCloseTo(
             parseFloat(MILLION_PERVISIT_GREY_DEVICES_SECOND.toFixed(5)),
-            3,
+            3
           );
           expect(
-            parseFloat(res["dataCenterCO2 - subsequent"].toFixed(5)),
+            parseFloat(res["dataCenterCO2 - subsequent"].toFixed(5))
           ).toBeCloseTo(
             parseFloat(MILLION_PERVISIT_GREEN_DATACENTERS_SECOND.toFixed(5)),
-            3,
+            3
           );
 
           expect(parseFloat(res.total.toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_PERVISIT_GREEN.toFixed(5)),
-            3,
+            3
           );
         });
       });
@@ -159,15 +159,15 @@ describe("co2", () => {
           const res = co2.perByte(MILLION, true);
           expect(parseFloat(res["consumerDeviceCO2"].toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREY_DEVICES.toFixed(5)),
-            3,
+            3
           );
           expect(parseFloat(res["dataCenterCO2"].toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREEN_DATACENTERS.toFixed(5)),
-            3,
+            3
           );
           expect(parseFloat(res.total.toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREEN.toFixed(5)),
-            3,
+            3
           );
         });
         it("returns an object with devices, networks, data centers, and production emissions shown separately, as well as the total emissions", () => {
@@ -175,23 +175,23 @@ describe("co2", () => {
           const res = co2.perByte(MILLION);
           expect(parseFloat(res["consumerDeviceCO2"].toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREY_DEVICES.toFixed(5)),
-            3,
+            3
           );
           expect(parseFloat(res["networkCO2"].toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREY_NETWORKS.toFixed(5)),
-            3,
+            3
           );
           expect(parseFloat(res["dataCenterCO2"].toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREY_DATACENTERS.toFixed(5)),
-            3,
+            3
           );
           expect(parseFloat(res["productionCO2"].toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREY_PRODUCTION.toFixed(5)),
-            3,
+            3
           );
           expect(parseFloat(res.total.toFixed(5))).toBeCloseTo(
             parseFloat(MILLION_GREY.toFixed(5)),
-            3,
+            3
           );
         });
       });
@@ -202,7 +202,7 @@ describe("co2", () => {
     // Test for error if incorrect model is passed
     it("throws an error if model is not valid", () => {
       expect(() => (co2 = new CO2({ model: "1direction" }))).toThrowError(
-        `"1direction" is not a valid model. Please use "1byte" for the OneByte model, and "swd" for the Sustainable Web Design model.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`,
+        `"1direction" is not a valid model. Please use "1byte" for the OneByte model, and "swd" for the Sustainable Web Design model.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`
       );
     });
 
@@ -212,7 +212,7 @@ describe("co2", () => {
         co2 = new CO2({ model: "1byte" });
         co2.perVisit(10);
       }).toThrowError(
-        `The perVisit() method is not supported in the model you are using. Try using perByte() instead.\nSee https://developers.thegreenwebfoundation.org/co2js/methods/ to learn more about the methods available in CO2.js.`,
+        `The perVisit() method is not supported in the model you are using. Try using perByte() instead.\nSee https://developers.thegreenwebfoundation.org/co2js/methods/ to learn more about the methods available in CO2.js.`
       );
     });
 
@@ -220,7 +220,7 @@ describe("co2", () => {
       expect(() => {
         co2 = new CO2({ model: "1byte", rating: true });
       }).toThrowError(
-        `The rating system is not supported in the model you are using. Try using the Sustainable Web Design model instead.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`,
+        `The rating system is not supported in the model you are using. Try using the Sustainable Web Design model instead.\nSee https://developers.thegreenwebfoundation.org/co2js/models/ to learn more about the models available in CO2.js.`
       );
     });
 
@@ -228,7 +228,7 @@ describe("co2", () => {
       expect(() => {
         co2 = new CO2({ rating: "false" });
       }).toThrowError(
-        `The rating option must be a boolean. Please use true or false.\nSee https://developers.thegreenwebfoundation.org/co2js/options/ to learn more about the options available in CO2.js.`,
+        `The rating option must be a boolean. Please use true or false.\nSee https://developers.thegreenwebfoundation.org/co2js/options/ to learn more about the options available in CO2.js.`
       );
     });
   });
@@ -253,20 +253,20 @@ describe("co2", () => {
     it("perByteTrace is the same as perByte", () => {
       expect(co2.perByteTrace(MILLION).co2).toBe(co2.perByte(MILLION));
       expect(co2.perByteTrace(MILLION, true).co2).toBe(
-        co2.perByte(MILLION, true),
+        co2.perByte(MILLION, true)
       );
       expect(co2.perByteTrace(MILLION, true, {}).co2).toBe(
-        co2.perByte(MILLION, true),
+        co2.perByte(MILLION, true)
       );
     });
 
     it("perVisitTrace is the same as perVisit", () => {
       expect(co2.perVisitTrace(MILLION).co2).toBe(co2.perVisit(MILLION));
       expect(co2.perVisitTrace(MILLION, true).co2).toBe(
-        co2.perVisit(MILLION, true),
+        co2.perVisit(MILLION, true)
       );
       expect(co2.perVisitTrace(MILLION, true, {}).co2).toBe(
-        co2.perVisit(MILLION, true),
+        co2.perVisit(MILLION, true)
       );
     });
 
@@ -275,25 +275,25 @@ describe("co2", () => {
       expect(co2.perByteTrace(MILLION)).toHaveProperty("variables");
       expect(co2.perByteTrace(MILLION)).toHaveProperty("green");
       expect(co2.perByteTrace(MILLION)).toHaveProperty(
-        "variables.gridIntensity",
+        "variables.gridIntensity"
       );
       expect(co2.perByteTrace(MILLION)).not.toHaveProperty(
-        "variables.firstVisitPercentage",
+        "variables.firstVisitPercentage"
       );
       expect(co2.perVisitTrace(MILLION)).toHaveProperty("co2");
       expect(co2.perVisitTrace(MILLION)).toHaveProperty("variables");
       expect(co2.perVisitTrace(MILLION)).toHaveProperty("green");
       expect(co2.perVisitTrace(MILLION)).toHaveProperty(
-        "variables.gridIntensity",
+        "variables.gridIntensity"
       );
       expect(co2.perVisitTrace(MILLION)).toHaveProperty(
-        "variables.firstVisitPercentage",
+        "variables.firstVisitPercentage"
       );
       expect(co2.perVisitTrace(MILLION)).toHaveProperty(
-        "variables.returnVisitPercentage",
+        "variables.returnVisitPercentage"
       );
       expect(co2.perVisitTrace(MILLION)).toHaveProperty(
-        "variables.dataReloadRatio",
+        "variables.dataReloadRatio"
       );
     });
   });
@@ -307,7 +307,7 @@ describe("co2", () => {
             device: 678.87,
             dataCenter: { country: "TWN" },
           },
-        }).co2,
+        }).co2
       ).toBeGreaterThan(0);
 
       expect(
@@ -317,7 +317,7 @@ describe("co2", () => {
             dataCenter: { country: "TWN" },
             network: { country: "TWN" },
           },
-        }).co2,
+        }).co2
       ).toBeGreaterThan(0);
     });
   });
@@ -339,8 +339,8 @@ describe("co2", () => {
                 device: "561",
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(MILLION_PERVISIT_GREY, 3);
 
       expect(
@@ -351,8 +351,8 @@ describe("co2", () => {
                 device: "561",
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(MILLION_GREY, 3);
     });
 
@@ -365,13 +365,13 @@ describe("co2", () => {
                 device: TwnGridIntensityValue,
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(
         parseFloat(
-          MILLION_PERVISIT_GREY_DEVICE_GRID_INTENSITY_CHANGE.toPrecision(5),
+          MILLION_PERVISIT_GREY_DEVICE_GRID_INTENSITY_CHANGE.toPrecision(5)
         ),
-        3,
+        3
       );
 
       expect(
@@ -382,13 +382,13 @@ describe("co2", () => {
                 device: TwnGridIntensityValue,
               },
             })
-            .co2.toPrecision(4),
-        ),
+            .co2.toPrecision(4)
+        )
       ).toBeCloseTo(
         parseFloat(
-          MILLION_PERBYTE_GREY_DEVICE_GRID_INTENSITY_CHANGE.toPrecision(4),
+          MILLION_PERBYTE_GREY_DEVICE_GRID_INTENSITY_CHANGE.toPrecision(4)
         ),
-        3,
+        3
       );
     });
 
@@ -403,8 +403,8 @@ describe("co2", () => {
                 },
               },
             })
-            .co2.toFixed(5),
-        ),
+            .co2.toFixed(5)
+        )
       ).toBeCloseTo(MILLION_PERVISIT_GREY_DEVICE_GRID_INTENSITY_CHANGE, 3);
       expect(
         parseFloat(
@@ -416,8 +416,8 @@ describe("co2", () => {
                 },
               },
             })
-            .co2.toPrecision(4),
-        ),
+            .co2.toPrecision(4)
+        )
       ).toBeCloseTo(MILLION_PERBYTE_GREY_DEVICE_GRID_INTENSITY_CHANGE, 3);
     });
   });
@@ -439,8 +439,8 @@ describe("co2", () => {
                 dataCenter: "565.629",
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(MILLION_PERVISIT_GREY, 3);
       expect(
         parseFloat(
@@ -450,8 +450,8 @@ describe("co2", () => {
                 dataCenter: "565.629",
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(MILLION_GREY, 3);
     });
 
@@ -464,13 +464,13 @@ describe("co2", () => {
                 dataCenter: TwnGridIntensityValue,
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(
         parseFloat(
-          MILLION_PERVISIT_GREY_DATACENTER_GRID_INTENSITY_CHANGE.toPrecision(5),
+          MILLION_PERVISIT_GREY_DATACENTER_GRID_INTENSITY_CHANGE.toPrecision(5)
         ),
-        3,
+        3
       );
       expect(
         parseFloat(
@@ -480,13 +480,13 @@ describe("co2", () => {
                 dataCenter: TwnGridIntensityValue,
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(
         parseFloat(
-          MILLION_PERBYTE_GREY_DATACENTER_GRID_INTENSITY_CHANGE.toPrecision(5),
+          MILLION_PERBYTE_GREY_DATACENTER_GRID_INTENSITY_CHANGE.toPrecision(5)
         ),
-        3,
+        3
       );
     });
 
@@ -501,8 +501,8 @@ describe("co2", () => {
                 },
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(MILLION_PERVISIT_GREY_DATACENTER_GRID_INTENSITY_CHANGE, 3);
       expect(
         parseFloat(
@@ -514,8 +514,8 @@ describe("co2", () => {
                 },
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(MILLION_PERBYTE_GREY_DATACENTER_GRID_INTENSITY_CHANGE, 3);
     });
   });
@@ -537,8 +537,8 @@ describe("co2", () => {
                 network: "561",
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(MILLION_PERVISIT_GREY, 3);
 
       expect(
@@ -549,8 +549,8 @@ describe("co2", () => {
                 network: "561",
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(MILLION_GREY, 3);
     });
 
@@ -563,13 +563,13 @@ describe("co2", () => {
                 network: TwnGridIntensityValue,
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(
         parseFloat(
-          MILLION_PERVISIT_GREY_NETWORK_GRID_INTENSITY_CHANGE.toFixed(5),
+          MILLION_PERVISIT_GREY_NETWORK_GRID_INTENSITY_CHANGE.toFixed(5)
         ),
-        3,
+        3
       );
       expect(
         parseFloat(
@@ -579,13 +579,13 @@ describe("co2", () => {
                 network: TwnGridIntensityValue,
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(
         parseFloat(
-          MILLION_PERBYTE_GREY_NETWORK_GRID_INTENSITY_CHANGE.toPrecision(5),
+          MILLION_PERBYTE_GREY_NETWORK_GRID_INTENSITY_CHANGE.toPrecision(5)
         ),
-        3,
+        3
       );
     });
 
@@ -600,8 +600,8 @@ describe("co2", () => {
                 },
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(MILLION_PERVISIT_GREY_NETWORK_GRID_INTENSITY_CHANGE, 3);
       expect(
         parseFloat(
@@ -613,8 +613,8 @@ describe("co2", () => {
                 },
               },
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(MILLION_PERBYTE_GREY_NETWORK_GRID_INTENSITY_CHANGE, 3);
     });
   });
@@ -626,7 +626,7 @@ describe("co2", () => {
       expect(
         co2.perVisitTrace(1000000, false, {
           dataReloadRatio: 0.5,
-        }).co2,
+        }).co2
       ).toBeGreaterThan(MILLION_PERVISIT_GREY);
     });
 
@@ -635,8 +635,8 @@ describe("co2", () => {
         parseFloat(
           co2
             .perVisitTrace(1000000, false, { dataReloadRatio: "0.5" })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(MILLION_PERVISIT_GREY, 3);
     });
 
@@ -647,8 +647,8 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               dataReloadRatio: 1.5,
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(MILLION_PERVISIT_GREY, 3);
       expect(
         parseFloat(
@@ -656,13 +656,13 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               dataReloadRatio: -1.5,
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(MILLION_PERVISIT_GREY, 3);
       expect(
         co2.perVisitTrace(1000000, false, {
           dataReloadRatio: 0,
-        }).co2,
+        }).co2
       ).toBeLessThan(MILLION_PERVISIT_GREY);
     });
   });
@@ -676,7 +676,7 @@ describe("co2", () => {
         co2.perVisitTrace(MILLION, false, {
           firstVisitPercentage: 0.8,
           returnVisitPercentage: 0.2,
-        }).co2,
+        }).co2
       ).toBeGreaterThan(MILLION_PERVISIT_GREY);
 
       expect(
@@ -686,8 +686,8 @@ describe("co2", () => {
               firstVisitPercentage: 0.8,
               returnVisitPercentage: 0.2,
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBeCloseTo(MILLION_GREY, 3);
     });
 
@@ -698,8 +698,8 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               firstVisitPercentage: "0.8",
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBe(MILLION_PERVISIT_GREY);
     });
     it("expects firstVisitPercentage to be a number between 0 and 1", () => {
@@ -710,8 +710,8 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               firstVisitPercentage: 1.5,
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBe(MILLION_PERVISIT_GREY);
       expect(
         parseFloat(
@@ -719,13 +719,13 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               firstVisitPercentage: -1.5,
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBe(MILLION_PERVISIT_GREY);
       expect(
         co2.perVisitTrace(1000000, false, {
           firstVisitPercentage: 0,
-        }).co2,
+        }).co2
       ).toBeLessThan(MILLION_PERVISIT_GREY);
     });
     it("expects returnVisitPercentage to be a number", () => {
@@ -735,8 +735,8 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               returnVisitPercentage: "0.5",
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBe(MILLION_PERVISIT_GREY);
     });
     it("expects returnVisitPercentage to be a number between 0 and 1", () => {
@@ -746,8 +746,8 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               returnVisitPercentage: 1.5,
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBe(MILLION_PERVISIT_GREY);
       expect(
         parseFloat(
@@ -755,13 +755,13 @@ describe("co2", () => {
             .perVisitTrace(1000000, false, {
               returnVisitPercentage: -1.5,
             })
-            .co2.toPrecision(5),
-        ),
+            .co2.toPrecision(5)
+        )
       ).toBe(MILLION_PERVISIT_GREY);
       expect(
         co2.perVisitTrace(1000000, false, {
           returnVisitPercentage: 0,
-        }).co2,
+        }).co2
       ).toBeLessThan(MILLION_PERVISIT_GREY);
     });
   });
@@ -933,13 +933,13 @@ describe("co2", () => {
       expect(res.variables.greenHostingFactor).toBe(0);
       expect(res.green).toBe(false);
       expect(res.variables.gridIntensity.device.value).toBe(
-        SWDM4_GLOBAL_GRID_INTENSITY,
+        SWDM4_GLOBAL_GRID_INTENSITY
       );
       expect(res.variables.gridIntensity.dataCenter.value).toBe(
-        SWDM4_GLOBAL_GRID_INTENSITY,
+        SWDM4_GLOBAL_GRID_INTENSITY
       );
       expect(res.variables.gridIntensity.network.value).toBe(
-        SWDM4_GLOBAL_GRID_INTENSITY,
+        SWDM4_GLOBAL_GRID_INTENSITY
       );
     });
     it("returns the expected object when adjustments are made", () => {
@@ -994,13 +994,13 @@ describe("co2", () => {
       expect(res.variables.returnVisitPercentage).toBe(0);
       expect(res.variables.dataReloadRatio).toBe(0);
       expect(res.variables.gridIntensity.device.value).toBe(
-        SWDM4_GLOBAL_GRID_INTENSITY,
+        SWDM4_GLOBAL_GRID_INTENSITY
       );
       expect(res.variables.gridIntensity.dataCenter.value).toBe(
-        SWDM4_GLOBAL_GRID_INTENSITY,
+        SWDM4_GLOBAL_GRID_INTENSITY
       );
       expect(res.variables.gridIntensity.network.value).toBe(
-        SWDM4_GLOBAL_GRID_INTENSITY,
+        SWDM4_GLOBAL_GRID_INTENSITY
       );
     });
     it("returns the expected object when adjustments are made", () => {

--- a/src/hosting-api.test.js
+++ b/src/hosting-api.test.js
@@ -1,12 +1,14 @@
 "use strict";
 
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import hosting from "./hosting-api.js";
 /* eslint-disable jest/no-disabled-tests */
 
 process.env.CO2JS_VERSION = "1.2.34";
 const requestHeaderComment = "TestRunner";
 
-global.fetch = jest.fn(() =>
+global.fetch = vi.fn(() =>
   Promise.resolve({
     json: () => Promise.resolve({ green: true }),
   })
@@ -24,7 +26,7 @@ describe("hostingAPI", () => {
         expect.any(String),
         expect.objectContaining({
           headers: { "User-Agent": "co2js/1.2.34 " },
-        })
+        }),
       );
       expect(res).toEqual(true);
     });
@@ -36,7 +38,7 @@ describe("hostingAPI", () => {
         expect.any(String),
         expect.objectContaining({
           headers: { "User-Agent": "co2js/1.2.34 TestRunner" },
-        })
+        }),
       );
       expect(res).toEqual(true);
     });
@@ -58,7 +60,7 @@ describe("hostingAPI", () => {
         expect.any(String),
         expect.objectContaining({
           headers: { "User-Agent": "co2js/1.2.34 " },
-        })
+        }),
       );
       expect(res).toMatchObject({
         green: true,
@@ -85,14 +87,14 @@ describe("hostingAPI", () => {
     it("sets the correct user agent header", async () => {
       const res = await hosting.check(
         ["google.com", "kochindustries.com"],
-        requestHeaderComment
+        requestHeaderComment,
       );
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(fetch).toHaveBeenLastCalledWith(
         expect.any(String),
         expect.objectContaining({
           headers: { "User-Agent": "co2js/1.2.34 TestRunner" },
-        })
+        }),
       );
       expect(res).toContain("google.com");
     });

--- a/src/hosting-api.test.js
+++ b/src/hosting-api.test.js
@@ -26,7 +26,7 @@ describe("hostingAPI", () => {
         expect.any(String),
         expect.objectContaining({
           headers: { "User-Agent": "co2js/1.2.34 " },
-        }),
+        })
       );
       expect(res).toEqual(true);
     });
@@ -38,7 +38,7 @@ describe("hostingAPI", () => {
         expect.any(String),
         expect.objectContaining({
           headers: { "User-Agent": "co2js/1.2.34 TestRunner" },
-        }),
+        })
       );
       expect(res).toEqual(true);
     });
@@ -60,7 +60,7 @@ describe("hostingAPI", () => {
         expect.any(String),
         expect.objectContaining({
           headers: { "User-Agent": "co2js/1.2.34 " },
-        }),
+        })
       );
       expect(res).toMatchObject({
         green: true,
@@ -87,14 +87,14 @@ describe("hostingAPI", () => {
     it("sets the correct user agent header", async () => {
       const res = await hosting.check(
         ["google.com", "kochindustries.com"],
-        requestHeaderComment,
+        requestHeaderComment
       );
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(fetch).toHaveBeenLastCalledWith(
         expect.any(String),
         expect.objectContaining({
           headers: { "User-Agent": "co2js/1.2.34 TestRunner" },
-        }),
+        })
       );
       expect(res).toContain("google.com");
     });

--- a/src/hosting-database.node.test.js
+++ b/src/hosting-database.node.test.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import { describe, expect, test } from "vitest";
+
 import path from "path";
 
 import { hosting } from "@tgwf/url2green";
@@ -9,7 +11,7 @@ const dbPath = path.resolve(
   "..",
   "data",
   "fixtures",
-  "url2green.test.db"
+  "url2green.test.db",
 );
 
 describe("hostingDatabase", () => {
@@ -23,7 +25,7 @@ describe("hostingDatabase", () => {
     test("tries to use a local database if available", async () => {
       const res = await hosting.check(
         ["google.com", "kochindustries.com"],
-        dbPath
+        dbPath,
       );
       expect(res).toContain("google.com");
     });

--- a/src/hosting-database.node.test.js
+++ b/src/hosting-database.node.test.js
@@ -11,7 +11,7 @@ const dbPath = path.resolve(
   "..",
   "data",
   "fixtures",
-  "url2green.test.db",
+  "url2green.test.db"
 );
 
 describe("hostingDatabase", () => {
@@ -25,7 +25,7 @@ describe("hostingDatabase", () => {
     test("tries to use a local database if available", async () => {
       const res = await hosting.check(
         ["google.com", "kochindustries.com"],
-        dbPath,
+        dbPath
       );
       expect(res).toContain("google.com");
     });

--- a/src/hosting-json.node.test.js
+++ b/src/hosting-json.node.test.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import { describe, expect, test } from "vitest";
+
 import hosting from "./hosting-json.js";
 import hostingNode from "./hosting-json.node.js";
 import path from "path";
@@ -10,14 +12,14 @@ describe("hostingJSON", () => {
     "..",
     "data",
     "fixtures",
-    "url2green.test.json"
+    "url2green.test.json",
   );
   const jsonPathGz = path.resolve(
     __dirname,
     "..",
     "data",
     "fixtures",
-    "url2green.test.json.gz"
+    "url2green.test.json.gz",
   );
   describe("checking a single domain with #check", () => {
     test("against the list of domains as JSON", async () => {

--- a/src/hosting-json.node.test.js
+++ b/src/hosting-json.node.test.js
@@ -12,14 +12,14 @@ describe("hostingJSON", () => {
     "..",
     "data",
     "fixtures",
-    "url2green.test.json",
+    "url2green.test.json"
   );
   const jsonPathGz = path.resolve(
     __dirname,
     "..",
     "data",
     "fixtures",
-    "url2green.test.json.gz",
+    "url2green.test.json.gz"
   );
   describe("checking a single domain with #check", () => {
     test("against the list of domains as JSON", async () => {

--- a/src/hosting.test.js
+++ b/src/hosting.test.js
@@ -3,9 +3,9 @@
 import https from "https";
 import path from "path";
 
-import hosting from "./hosting-node.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-jest.mock("https");
+import hosting from "./hosting-node.js";
 
 process.env.CO2JS_VERSION = "1.2.34";
 const requestHeaderComment = "TestRunner";
@@ -15,21 +15,21 @@ const jsonPath = path.resolve(
   "..",
   "data",
   "fixtures",
-  "url2green.test.json"
+  "url2green.test.json",
 );
 
 describe("hosting", () => {
   let httpsGetSpy;
   beforeEach(() => {
-    httpsGetSpy = jest.spyOn(https, "get");
-    jest.clearAllMocks();
+    httpsGetSpy = vi.spyOn(https, "get");
+    vi.clearAllMocks();
   });
   describe("checking domains against a db snapshot", () => {
     it("returns a list of green domains, when passed a database array", async () => {
       const db = await hosting.loadJSON(jsonPath);
       const greenDomains = await hosting.check(
         ["www.thegreenwebfoundation.org", "fonts.googleapis.com"],
-        db
+        db,
       );
 
       expect(greenDomains).toHaveLength(2);
@@ -38,7 +38,7 @@ describe("hosting", () => {
       const db = await hosting.loadJSON(jsonPath);
       const greenDomains = await hosting.check(
         ["www.thegreenwebfoundation.org", "fonts.googleapis.com"],
-        { db }
+        { db },
       );
 
       expect(greenDomains).toHaveLength(2);
@@ -48,10 +48,10 @@ describe("hosting", () => {
       await expect(() => {
         hosting.check(
           ["www.thegreenwebfoundation.org", "fonts.googleapis.com"],
-          { verbose: true, db }
+          { verbose: true, db },
         );
       }).toThrowError(
-        "verbose mode cannot be used with a local lookup database"
+        "verbose mode cannot be used with a local lookup database",
       );
     });
   });
@@ -81,7 +81,7 @@ describe("hosting", () => {
         expect.objectContaining({
           headers: { "User-Agent": "co2js/1.2.34 TestRunner" },
         }),
-        expect.any(Function)
+        expect.any(Function),
       );
     });
     it("sets the correct user agent header when passed as a parameter", async () => {
@@ -92,7 +92,7 @@ describe("hosting", () => {
         expect.objectContaining({
           headers: { "User-Agent": "co2js/1.2.34 TestRunner" },
         }),
-        expect.any(Function)
+        expect.any(Function),
       );
     });
   });

--- a/src/hosting.test.js
+++ b/src/hosting.test.js
@@ -15,7 +15,7 @@ const jsonPath = path.resolve(
   "..",
   "data",
   "fixtures",
-  "url2green.test.json",
+  "url2green.test.json"
 );
 
 describe("hosting", () => {
@@ -29,7 +29,7 @@ describe("hosting", () => {
       const db = await hosting.loadJSON(jsonPath);
       const greenDomains = await hosting.check(
         ["www.thegreenwebfoundation.org", "fonts.googleapis.com"],
-        db,
+        db
       );
 
       expect(greenDomains).toHaveLength(2);
@@ -38,7 +38,7 @@ describe("hosting", () => {
       const db = await hosting.loadJSON(jsonPath);
       const greenDomains = await hosting.check(
         ["www.thegreenwebfoundation.org", "fonts.googleapis.com"],
-        { db },
+        { db }
       );
 
       expect(greenDomains).toHaveLength(2);
@@ -48,10 +48,10 @@ describe("hosting", () => {
       await expect(() => {
         hosting.check(
           ["www.thegreenwebfoundation.org", "fonts.googleapis.com"],
-          { verbose: true, db },
+          { verbose: true, db }
         );
       }).toThrowError(
-        "verbose mode cannot be used with a local lookup database",
+        "verbose mode cannot be used with a local lookup database"
       );
     });
   });
@@ -81,7 +81,7 @@ describe("hosting", () => {
         expect.objectContaining({
           headers: { "User-Agent": "co2js/1.2.34 TestRunner" },
         }),
-        expect.any(Function),
+        expect.any(Function)
       );
     });
     it("sets the correct user agent header when passed as a parameter", async () => {
@@ -92,7 +92,7 @@ describe("hosting", () => {
         expect.objectContaining({
           headers: { "User-Agent": "co2js/1.2.34 TestRunner" },
         }),
-        expect.any(Function),
+        expect.any(Function)
       );
     });
   });

--- a/src/sustainable-web-design-v3.test.js
+++ b/src/sustainable-web-design-v3.test.js
@@ -65,16 +65,16 @@ describe("sustainable web design model version 3", () => {
 
       expect(result.dataCenterCO2).toBeCloseTo(
         SWDV3.MILLION_GREY_DATACENTERS,
-        3,
+        3
       );
       expect(result.consumerDeviceCO2).toBeCloseTo(
         SWDV3.MILLION_GREY_DEVICES,
-        3,
+        3
       );
       expect(result.networkCO2).toBeCloseTo(SWDV3.MILLION_GREY_NETWORKS, 3);
       expect(result.productionCO2).toBeCloseTo(
         SWDV3.MILLION_GREY_PRODUCTION,
-        3,
+        3
       );
       expect(result.total).toBeCloseTo(SWDV3.MILLION_GREY, 3);
     });
@@ -93,7 +93,7 @@ describe("sustainable web design model version 3", () => {
 
     it("should calculate the correct energy", () => {
       expect(swd.energyPerVisit(averageWebsiteInBytes)).toBe(
-        0.0013807057305600004,
+        0.0013807057305600004
       );
     });
   });
@@ -119,7 +119,7 @@ describe("sustainable web design model version 3", () => {
   describe("annualEmissionsInGrams", () => {
     it("should calculate the corrent energy in grams", () => {
       expect(swd.annualEmissionsInGrams(averageWebsiteInBytes)).toBe(
-        27092582400,
+        27092582400
       );
     });
   });

--- a/src/sustainable-web-design-v3.test.js
+++ b/src/sustainable-web-design-v3.test.js
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import SustainableWebDesign from "./sustainable-web-design-v3.js";
 import { MILLION, SWDV3 } from "./constants/test-constants.js";
 import { SWDMV3_RATINGS } from "./constants/index.js";
@@ -63,16 +65,16 @@ describe("sustainable web design model version 3", () => {
 
       expect(result.dataCenterCO2).toBeCloseTo(
         SWDV3.MILLION_GREY_DATACENTERS,
-        3
+        3,
       );
       expect(result.consumerDeviceCO2).toBeCloseTo(
         SWDV3.MILLION_GREY_DEVICES,
-        3
+        3,
       );
       expect(result.networkCO2).toBeCloseTo(SWDV3.MILLION_GREY_NETWORKS, 3);
       expect(result.productionCO2).toBeCloseTo(
         SWDV3.MILLION_GREY_PRODUCTION,
-        3
+        3,
       );
       expect(result.total).toBeCloseTo(SWDV3.MILLION_GREY, 3);
     });
@@ -91,7 +93,7 @@ describe("sustainable web design model version 3", () => {
 
     it("should calculate the correct energy", () => {
       expect(swd.energyPerVisit(averageWebsiteInBytes)).toBe(
-        0.0013807057305600004
+        0.0013807057305600004,
       );
     });
   });
@@ -117,7 +119,7 @@ describe("sustainable web design model version 3", () => {
   describe("annualEmissionsInGrams", () => {
     it("should calculate the corrent energy in grams", () => {
       expect(swd.annualEmissionsInGrams(averageWebsiteInBytes)).toBe(
-        27092582400
+        27092582400,
       );
     });
   });

--- a/src/sustainable-web-design-v4.test.js
+++ b/src/sustainable-web-design-v4.test.js
@@ -25,7 +25,7 @@ describe("sustainable web design model version 4", () => {
           dataCenter: expect.any(Number),
           network: expect.any(Number),
           device: expect.any(Number),
-        }),
+        })
       );
       expect(result.dataCenter).toBeCloseTo(27.17, 3);
       expect(result.network).toBeCloseTo(29.146, 3);
@@ -39,7 +39,7 @@ describe("sustainable web design model version 4", () => {
           dataCenter: expect.any(Number),
           network: expect.any(Number),
           device: expect.any(Number),
-        }),
+        })
       );
       expect(result.dataCenter).toBeCloseTo(0, 3);
       expect(result.network).toBeCloseTo(0, 3);
@@ -60,7 +60,7 @@ describe("sustainable web design model version 4", () => {
           dataCenter: expect.any(Number),
           network: expect.any(Number),
           device: expect.any(Number),
-        }),
+        })
       );
       expect(result.dataCenter).toBeCloseTo(5.5, 3);
       expect(result.network).toBeCloseTo(11.8, 3);
@@ -76,7 +76,7 @@ describe("sustainable web design model version 4", () => {
           dataCenter: expect.any(Number),
           network: expect.any(Number),
           device: expect.any(Number),
-        }),
+        })
       );
       expect(result.dataCenter).toBeCloseTo(5.928, 3);
       expect(result.network).toBeCloseTo(6.422, 3);
@@ -90,7 +90,7 @@ describe("sustainable web design model version 4", () => {
           dataCenter: expect.any(Number),
           network: expect.any(Number),
           device: expect.any(Number),
-        }),
+        })
       );
       expect(result.dataCenter).toBeCloseTo(0, 3);
       expect(result.network).toBeCloseTo(0, 3);
@@ -138,49 +138,49 @@ describe("sustainable web design model version 4", () => {
           networkCO2e: expect.any(Number),
           consumerDeviceCO2e: expect.any(Number),
           total: expect.any(Number),
-        }),
+        })
       );
 
       expect(result.dataCenterOperationalCO2e).toBeCloseTo(
         SWDV4.DC_OPERATIONAL_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.networkOperationalCO2e).toBeCloseTo(
         SWDV4.NETWORK_OPERATIONAL_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.consumerDeviceOperationalCO2e).toBeCloseTo(
         SWDV4.DEVICE_OPERATIONAL_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.totalOperationalCO2e).toBeCloseTo(
         SWDV4.TOTAL_OPERATIONAL_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.dataCenterEmbodiedCO2e).toBeCloseTo(
         SWDV4.DC_EMBODIED_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.networkEmbodiedCO2e).toBeCloseTo(
         SWDV4.NETWORK_EMBODIED_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.consumerDeviceEmbodiedCO2e).toBeCloseTo(
         SWDV4.DEVICE_EMBODIED_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.totalEmbodiedCO2e).toBeCloseTo(
         SWDV4.TOTAL_EMBODIED_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.dataCenterCO2e).toBeCloseTo(SWDV4.TOTAL_DC_EMISSIONS_GB, 3);
       expect(result.networkCO2e).toBeCloseTo(
         SWDV4.TOTAL_NETWORK_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.consumerDeviceCO2e).toBeCloseTo(
         SWDV4.TOTAL_DEVICE_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.total).toBeCloseTo(SWDV4.PERBYTE_EMISSIONS_GB, 3);
     });
@@ -192,7 +192,7 @@ describe("sustainable web design model version 4", () => {
         expect.objectContaining({
           rating: expect.any(String),
           total: expect.any(Number),
-        }),
+        })
       );
 
       expect(result.rating).toBe("F");
@@ -216,7 +216,7 @@ describe("sustainable web design model version 4", () => {
           networkCO2e: expect.any(Number),
           consumerDeviceCO2e: expect.any(Number),
           total: expect.any(Number),
-        }),
+        })
       );
 
       expect(result.rating).toBe("F");
@@ -280,49 +280,49 @@ describe("sustainable web design model version 4", () => {
           firstVisitCO2e: expect.any(Number),
           returnVisitCO2e: expect.any(Number),
           total: expect.any(Number),
-        }),
+        })
       );
 
       expect(result.dataCenterOperationalCO2e).toBeCloseTo(
         SWDV4.DC_OPERATIONAL_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.networkOperationalCO2e).toBeCloseTo(
         SWDV4.NETWORK_OPERATIONAL_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.consumerDeviceOperationalCO2e).toBeCloseTo(
         SWDV4.DEVICE_OPERATIONAL_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.totalOperationalCO2e).toBeCloseTo(
         SWDV4.TOTAL_OPERATIONAL_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.dataCenterEmbodiedCO2e).toBeCloseTo(
         SWDV4.DC_EMBODIED_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.networkEmbodiedCO2e).toBeCloseTo(
         SWDV4.NETWORK_EMBODIED_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.consumerDeviceEmbodiedCO2e).toBeCloseTo(
         SWDV4.DEVICE_EMBODIED_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.totalEmbodiedCO2e).toBeCloseTo(
         SWDV4.TOTAL_EMBODIED_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.dataCenterCO2e).toBeCloseTo(SWDV4.TOTAL_DC_EMISSIONS_GB, 3);
       expect(result.networkCO2e).toBeCloseTo(
         SWDV4.TOTAL_NETWORK_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.consumerDeviceCO2e).toBeCloseTo(
         SWDV4.TOTAL_DEVICE_EMISSIONS_GB,
-        3,
+        3
       );
       expect(result.firstVisitCO2e).toBeCloseTo(148.2, 3);
       expect(result.returnVisitCO2e).toBeCloseTo(118.56, 3);
@@ -336,7 +336,7 @@ describe("sustainable web design model version 4", () => {
         expect.objectContaining({
           rating: expect.any(String),
           total: expect.any(Number),
-        }),
+        })
       );
 
       expect(result.rating).toBe("F");
@@ -362,7 +362,7 @@ describe("sustainable web design model version 4", () => {
           firstVisitCO2e: expect.any(Number),
           returnVisitCO2e: expect.any(Number),
           total: expect.any(Number),
-        }),
+        })
       );
 
       expect(result.rating).toBe("F");

--- a/src/sustainable-web-design-v4.test.js
+++ b/src/sustainable-web-design-v4.test.js
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import SustainableWebDesign from "./sustainable-web-design-v4.js";
 import { MILLION, SWDV4 } from "./constants/test-constants.js";
 import { GIGABYTE } from "./constants/file-size.js";
@@ -23,7 +25,7 @@ describe("sustainable web design model version 4", () => {
           dataCenter: expect.any(Number),
           network: expect.any(Number),
           device: expect.any(Number),
-        })
+        }),
       );
       expect(result.dataCenter).toBeCloseTo(27.17, 3);
       expect(result.network).toBeCloseTo(29.146, 3);
@@ -37,7 +39,7 @@ describe("sustainable web design model version 4", () => {
           dataCenter: expect.any(Number),
           network: expect.any(Number),
           device: expect.any(Number),
-        })
+        }),
       );
       expect(result.dataCenter).toBeCloseTo(0, 3);
       expect(result.network).toBeCloseTo(0, 3);
@@ -58,7 +60,7 @@ describe("sustainable web design model version 4", () => {
           dataCenter: expect.any(Number),
           network: expect.any(Number),
           device: expect.any(Number),
-        })
+        }),
       );
       expect(result.dataCenter).toBeCloseTo(5.5, 3);
       expect(result.network).toBeCloseTo(11.8, 3);
@@ -74,7 +76,7 @@ describe("sustainable web design model version 4", () => {
           dataCenter: expect.any(Number),
           network: expect.any(Number),
           device: expect.any(Number),
-        })
+        }),
       );
       expect(result.dataCenter).toBeCloseTo(5.928, 3);
       expect(result.network).toBeCloseTo(6.422, 3);
@@ -88,7 +90,7 @@ describe("sustainable web design model version 4", () => {
           dataCenter: expect.any(Number),
           network: expect.any(Number),
           device: expect.any(Number),
-        })
+        }),
       );
       expect(result.dataCenter).toBeCloseTo(0, 3);
       expect(result.network).toBeCloseTo(0, 3);
@@ -136,49 +138,49 @@ describe("sustainable web design model version 4", () => {
           networkCO2e: expect.any(Number),
           consumerDeviceCO2e: expect.any(Number),
           total: expect.any(Number),
-        })
+        }),
       );
 
       expect(result.dataCenterOperationalCO2e).toBeCloseTo(
         SWDV4.DC_OPERATIONAL_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.networkOperationalCO2e).toBeCloseTo(
         SWDV4.NETWORK_OPERATIONAL_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.consumerDeviceOperationalCO2e).toBeCloseTo(
         SWDV4.DEVICE_OPERATIONAL_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.totalOperationalCO2e).toBeCloseTo(
         SWDV4.TOTAL_OPERATIONAL_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.dataCenterEmbodiedCO2e).toBeCloseTo(
         SWDV4.DC_EMBODIED_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.networkEmbodiedCO2e).toBeCloseTo(
         SWDV4.NETWORK_EMBODIED_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.consumerDeviceEmbodiedCO2e).toBeCloseTo(
         SWDV4.DEVICE_EMBODIED_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.totalEmbodiedCO2e).toBeCloseTo(
         SWDV4.TOTAL_EMBODIED_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.dataCenterCO2e).toBeCloseTo(SWDV4.TOTAL_DC_EMISSIONS_GB, 3);
       expect(result.networkCO2e).toBeCloseTo(
         SWDV4.TOTAL_NETWORK_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.consumerDeviceCO2e).toBeCloseTo(
         SWDV4.TOTAL_DEVICE_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.total).toBeCloseTo(SWDV4.PERBYTE_EMISSIONS_GB, 3);
     });
@@ -190,7 +192,7 @@ describe("sustainable web design model version 4", () => {
         expect.objectContaining({
           rating: expect.any(String),
           total: expect.any(Number),
-        })
+        }),
       );
 
       expect(result.rating).toBe("F");
@@ -214,7 +216,7 @@ describe("sustainable web design model version 4", () => {
           networkCO2e: expect.any(Number),
           consumerDeviceCO2e: expect.any(Number),
           total: expect.any(Number),
-        })
+        }),
       );
 
       expect(result.rating).toBe("F");
@@ -278,49 +280,49 @@ describe("sustainable web design model version 4", () => {
           firstVisitCO2e: expect.any(Number),
           returnVisitCO2e: expect.any(Number),
           total: expect.any(Number),
-        })
+        }),
       );
 
       expect(result.dataCenterOperationalCO2e).toBeCloseTo(
         SWDV4.DC_OPERATIONAL_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.networkOperationalCO2e).toBeCloseTo(
         SWDV4.NETWORK_OPERATIONAL_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.consumerDeviceOperationalCO2e).toBeCloseTo(
         SWDV4.DEVICE_OPERATIONAL_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.totalOperationalCO2e).toBeCloseTo(
         SWDV4.TOTAL_OPERATIONAL_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.dataCenterEmbodiedCO2e).toBeCloseTo(
         SWDV4.DC_EMBODIED_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.networkEmbodiedCO2e).toBeCloseTo(
         SWDV4.NETWORK_EMBODIED_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.consumerDeviceEmbodiedCO2e).toBeCloseTo(
         SWDV4.DEVICE_EMBODIED_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.totalEmbodiedCO2e).toBeCloseTo(
         SWDV4.TOTAL_EMBODIED_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.dataCenterCO2e).toBeCloseTo(SWDV4.TOTAL_DC_EMISSIONS_GB, 3);
       expect(result.networkCO2e).toBeCloseTo(
         SWDV4.TOTAL_NETWORK_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.consumerDeviceCO2e).toBeCloseTo(
         SWDV4.TOTAL_DEVICE_EMISSIONS_GB,
-        3
+        3,
       );
       expect(result.firstVisitCO2e).toBeCloseTo(148.2, 3);
       expect(result.returnVisitCO2e).toBeCloseTo(118.56, 3);
@@ -334,7 +336,7 @@ describe("sustainable web design model version 4", () => {
         expect.objectContaining({
           rating: expect.any(String),
           total: expect.any(Number),
-        })
+        }),
       );
 
       expect(result.rating).toBe("F");
@@ -360,7 +362,7 @@ describe("sustainable web design model version 4", () => {
           firstVisitCO2e: expect.any(Number),
           returnVisitCO2e: expect.any(Number),
           total: expect.any(Number),
-        })
+        }),
       );
 
       expect(result.rating).toBe("F");


### PR DESCRIPTION
## Triage

### Type of change

Please select any of the below items that are appropriate.

This pull request:

- [ ] Adds a new carbon estimation model to CO2.js
- [ ] Adds new functionality to an existing model
- [ ] Fixes a bug with an existing model implementation
- [ ] Add other new functionality to CO2.js
- [ ] Add new data to CO2.js
- [x] Improves developer experience for contributors
- [ ] Adds contributors to CO2.js
- [ ] Does something not specified above

### Related issue/s

Please list below any issues this pull request is related to.

- #

### Docs changes required

Do any changes made in this pull request require parts of the [CO2.js documentation](https://developers.thegreenwebfoundation.org/co2js/overview/) to be updated?

- [x] Yes
- [ ] No
- [ ] I don't know

If you answered "Yes", please create an corresponding issue in our [Developer Documentation repository](https://github.com/thegreenwebfoundation/developer-docs).

## Describe the changes made in this pull request

This is a test PR as an experiment in trying out Vitest, a more actively maintained testing library than Jest. It also seems to be faster to run, and was not too complicated to try migrating the exiting codebase to use it instead of jest.

**Update**: actually, I don't think it's that much faster to run, but the output is clearer in terms of showing where the slow tests are:

_With jest_

> PASS src/sustainable-web-design-v3.test.js
> PASS src/sustainable-web-design-v4.test.js
> PASS src/co2.test.js
> PASS src/hosting-api.test.js
> PASS src/hosting.test.js
> PASS src/1byte.test.js
> PASS src/hosting-json.node.test.js
> PASS src/hosting-database.node.test.js
> 
> Test Suites: 8 passed, 8 total
> Tests:       113 passed, 113 total
> Snapshots:   0 total
> Time:        1.293 s
> Ran all test suites matching /src/i.


_With vitest_

---
> 
> ✓ src/co2.test.js  (51 tests) 41ms
>  ✓ src/hosting-api.test.js  (6 tests) 13ms
>  ✓ src/hosting-json.node.test.js  (3 tests) 14ms
>  ✓ src/1byte.test.js  (3 tests) 4ms
>  ✓ src/hosting-database.node.test.js  (2 tests) 14ms
>  ✓ src/hosting.test.js  (9 tests) 1491ms
>   ✓ hosting > checking a single domain with #check > use the API instead 579ms
>
> Test 
> Files  8 passed (8)
> Tests  113 passed (113)
>
>    Start at  18:56:56
>    Duration  2.10s (transform 169ms, setup 0ms, collect 433ms, tests 1.60s, environment 2ms, prepare 636ms)
> 

Note: I think eslint relies on jest, so jest is still bundled into the dev dependencies for package.json.

_As clearly as possible, describe the changes made in the pull request. You should at least detail "what changes have been made" and "what the results of these changes will be"._

The main changes are 


### Testing Framework Migration:

* Migrated from Jest to Vitest in `package.json` and updated test scripts 
* Updated test files to use Vitest imports and mocks (`__mocks__/https.js`)

### Workflow Configuration:

* Updated Node.js versions in `.github/workflows/unittests.yml` to [18.x, 20.x, 22.x] and updated actions versions 

### Dependency Updates:

* Updated `@tgwf/url2green` to version `^0.4.1` in `package.json` (this was needed to run npm install successfully. It can be added separately)
* Added `vitest` as a new dependency in `package.json` 


**Note:** There's no need to merge this in. We probably want to break this PR up into separate changes as there are three separate kinds of changes here (bumping url2green, updating unit tests, and then adding migrating to vitest). It was just a quick experiment after I tried vitest on url2green, and wondered how much work it might be to use in co2.js. 
