### PR TITLE
Update supported versions of nodejs in tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -2,29 +2,30 @@ name: Unit tests
 on:
   push:
     branches:
-    - main
-    - ca-v0.10.0
+      - main
   pull_request:
     branches:
-    - main
-    - ca-v0.10.0
+      - main
 permissions:
-    contents: read
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
+    # We officially support LTS versions of nodejs still inside
+    # their security support window
+    # https://endoflife.date/nodejs
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install
-      run: npm ci
-    - name: Verify lint
-      run: npm run lint
-    - name: Run unit tests
-      run: npm test
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install
+        run: npm ci
+      - name: Verify lint
+        run: npm run lint
+      - name: Run unit tests
+        run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ability to create adaptors which provide access to external data sources #134
 - Add access to the Electricity Maps API free tier #134
 - Allow access to individual models and their internal functions #195
+- Update the Github actions testing matrix to Node 18,20, and 22 #242
 <!-- - _(Add a summary of your feature, and if relevant the issue, in your PR for merging into `main`)_ -->
 
 ## Released


### PR DESCRIPTION
## Triage

### Type of change

Please select any of the below items that are appropriate.

This pull request:

- [ ] Adds a new carbon estimation model to CO2.js
- [ ] Adds new functionality to an existing model
- [ ] Fixes a bug with an existing model implementation
- [ ] Add other new functionality to CO2.js
- [ ] Add new data to CO2.js
- [x] Improves developer experience for contributors
- [ ] Adds contributors to CO2.js
- [ ] Does something not specified above

### Related issue/s

Please list below any issues this pull request is related to.

- #

### Docs changes required

Do any changes made in this pull request require parts of the [CO2.js documentation](https://developers.thegreenwebfoundation.org/co2js/overview/) to be updated?

- [ ] Yes
- [x] No
- [ ] I don't know

If you answered "Yes", please create an corresponding issue in our [Developer Documentation repository](https://github.com/thegreenwebfoundation/developer-docs).

## Describe the changes made in this pull request

This pull request includes updates to the GitHub Actions workflow configuration for running unit tests. The changes primarily focus on updating the supported Node.js versions to ones that are inside Nodejs own support window, and updates the actions used in the workflow to use newer versions.

Previously we were running NodeJs on unsupported versions of node, and this was causing failing tests in PRs that shouldn't really have them. See #241 as an example of a PR with failing tests related to the use of Node 14.

Updates to GitHub Actions workflow:

* [`.github/workflows/unittests.yml`](diffhunk://#diff-54c039feb42ef7c758e4cbc3aaa48971a1b41a1132399420b4c98d984ad62828L6-R23): Removed support for the `ca-v0.10.0` branch from both `push` and `pull_request` events.
* [`.github/workflows/unittests.yml`](diffhunk://#diff-54c039feb42ef7c758e4cbc3aaa48971a1b41a1132399420b4c98d984ad62828L6-R23): Updated the supported Node.js versions in the matrix strategy to `18.x`, `20.x`, and `22.x`.
* [`.github/workflows/unittests.yml`](diffhunk://#diff-54c039feb42ef7c758e4cbc3aaa48971a1b41a1132399420b4c98d984ad62828L6-R23): Updated `actions/checkout` to version `v4` and `actions/setup-node` to version `v4`.