### PR TITLE
Update carbon intensity comment to note the correct year

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -14,7 +14,7 @@ const DATACENTER_ENERGY = 0.15;
 const PRODUCTION_ENERGY = 0.19;
 
 // These carbon intensity figures https://ember-climate.org/data/data-explorer
-// - Global carbon intensity for 2022
+// - Global carbon intensity for 2023
 const GLOBAL_GRID_INTENSITY = averageIntensity.data["WORLD"];
 const RENEWABLES_GRID_INTENSITY = 50;
 


### PR DESCRIPTION
It might also be better longer-term to remove this comment :)

## Triage

### Type of change

Please select any of the below items that are appropriate.

This pull request:

- [ ] Adds a new carbon estimation model to CO2.js
- [ ] Adds new functionality to an existing model
- [ ] Fixes a bug with an existing model implementation
- [ ] Add other new functionality to CO2.js
- [ ] Add new data to CO2.js
- [x] Improves developer experience for contributors
- [ ] Adds contributors to CO2.js
- [ ] Does something not specified above

### Related issue/s

None

### Docs changes required

Do any changes made in this pull request require parts of the [CO2.js documentation](https://developers.thegreenwebfoundation.org/co2js/overview/) to be updated?

- [ ] Yes
- [ ] No
- [x] I don't know

If you answered "Yes", please create an corresponding issue in our [Developer Documentation repository](https://github.com/thegreenwebfoundation/developer-docs).

## Describe the changes made in this pull request

The Ember data pulled from the API has been returning 2023 figures for quite a while, as far as I can see the figures added to co2.js are from 2023.